### PR TITLE
Adiciona categorias de trabalho no endpoint de listagem de projetos

### DIFF
--- a/api_doc.md
+++ b/api_doc.md
@@ -18,13 +18,29 @@ Retorna a lista de todos os projetos cadastradas. (Status: 200):
     "id": 1,
     "title": "Projeto Master",
     "description": "Principal projeto criado",
-    "category": "Video"
+    "category": "Video",
+    "project_job_categories": [
+      {
+        "job_category_id": 1
+      },
+      {
+        "job_category_id": 2
+      }
+    ]
   },
   {
     "id": 2,
     "title": "Projeto Website",
     "description": "Um site de jogos",
-    "category": "Programação"
+    "category": "Programação",
+    "project_job_categories": [
+      {
+        "job_category_id": 1
+      },
+      {
+        "job_category_id": 2
+      }
+    ]
   }
 ]
 ```

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -4,10 +4,8 @@ module Api
       def index
         response = Project.all.as_json(
           only: %i[id title description category],
-            include: {
-              project_job_categories: { only: [:job_category_id] }
-            }
-          )
+          include: { project_job_categories: { only: [:job_category_id] } }
+        )
 
         response = { message: 'Nenhum projeto encontrado.' } if response.empty?
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -2,7 +2,12 @@ module Api
   module V1
     class ProjectsController < Api::V1::ApiController
       def index
-        response = Project.all.as_json(only: %i[id title description category])
+        response = Project.all.as_json(
+          only: %i[id title description category],
+            include: {
+              project_job_categories: { only: [:job_category_id] }
+            }
+          )
 
         response = { message: 'Nenhum projeto encontrado.' } if response.empty?
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_01_123256) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "documents", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,8 +59,15 @@ encrenca_project.user_roles.create!([{ user: jessie, role: :admin }])
 
 ash_project = FactoryBot.create(:project, user: ash, title: 'Pousadaria', category: 'Aplicação WEB')
 ash_project2 = FactoryBot.create(:project, user: ash, title: 'Portfoliorr', category: 'Aplicação WEB')
-pokemon_project = FactoryBot.create(:project, user: brock, title: 'Líder de Ginásio',
-                                    description: 'Me tornar líder do estádio de pedra.')
+
+
+
+first_project_job_category = FactoryBot.create(:project_job_category, project: pokemon_project, job_category_id: 1)
+
+second_project_job_category = FactoryBot.create(:project_job_category, project: pokemon_project, job_category_id: 2)
+
+third_project_job_category = FactoryBot.create(:project_job_category, project: encrenca_project, job_category_id: 1)
+
 
 
 FactoryBot.create(:task, project: pokemon_project, title:'Pegar um geodude',

--- a/spec/requests/api/v1/projects_api_spec.rb
+++ b/spec/requests/api/v1/projects_api_spec.rb
@@ -4,10 +4,13 @@ describe 'Project API' do
   context 'GET /api/v1/projects' do
     it 'com sucesso' do
       project_owner = create(:user)
-      create(:project, user: project_owner, title: 'Primeiro Projeto',
-                       description: 'Esse é o primeiro projeto', category: 'Site')
+      project = create(:project, user: project_owner, title: 'Primeiro Projeto',
+                                 description: 'Esse é o primeiro projeto', category: 'Site')
       create(:project, user: project_owner, title: 'Segundo Projeto',
                        description: 'Projeto de edição', category: 'Video')
+
+      create(:project_job_category, project:, job_category_id: 1)
+      create(:project_job_category, project:, job_category_id: 2)
 
       get '/api/v1/projects'
 
@@ -19,10 +22,13 @@ describe 'Project API' do
       expect(json_response[0]['title']).to eq 'Primeiro Projeto'
       expect(json_response[0]['description']).to eq 'Esse é o primeiro projeto'
       expect(json_response[0]['category']).to eq 'Site'
+      expect(json_response[0]['project_job_categories'][0]['job_category_id']).to eq 1
+      expect(json_response[0]['project_job_categories'][1]['job_category_id']).to eq 2
       expect(json_response[1]['id']).to eq 2
       expect(json_response[1]['title']).to eq 'Segundo Projeto'
       expect(json_response[1]['description']).to eq 'Projeto de edição'
       expect(json_response[1]['category']).to eq 'Video'
+      expect(json_response[1]['project_job_categories'].any?).to eq false
     end
 
     it 'e não tem nenhum projeto' do

--- a/spec/system/profiles/user_edit_profile_spec.rb
+++ b/spec/system/profiles/user_edit_profile_spec.rb
@@ -67,7 +67,7 @@ describe 'Usuário edita perfil' do
       visit edit_profile_path user.profile
       click_on 'Pular etapa'
 
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     it 'e já tem informação registrada' do
@@ -79,7 +79,7 @@ describe 'Usuário edita perfil' do
       visit edit_profile_path user.profile
       click_on 'Voltar'
 
-      expect(current_path).to eq profile_path user.profile
+      expect(page).to have_current_path profile_path user.profile
     end
   end
 


### PR DESCRIPTION
# Alcançamos com este PR

Esse PR resolve as issues #59 #60 

- Adicionamos um novo atributo no endpoint de listagem de projetos, referente ao model `ProjectJobCategory`, com o tipo array que possui hashes incluindo apenas o atributo `job_category_id` de cada objeto.

- Adicionamos seeds para `ProjectJobCategory`

- Adicionamos `project_job_category` na documentação de API

## Tela

- Resultado da requisição da API de listagem de Projetos
 
![Captura de tela de 2024-02-01 17-53-27](https://github.com/TreinaDev/td11-cola-bora/assets/116985618/1300e05c-c249-44d1-b750-378a9728d747)
