### PR TITLE
Altera url de endpoint de convites

### DIFF
--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class InvitationsController < Api::V1::ApiController
       def index
-        @invitations = Invitation.pending.where(profile_id: params[:id])
+        @invitations = Invitation.pending.where(profile_id: params[:profile_id])
         render status: :ok, json: set_json
       end
 

--- a/spec/requests/api/v1/invitation_search_api_spec.rb
+++ b/spec/requests/api/v1/invitation_search_api_spec.rb
@@ -17,7 +17,7 @@ describe 'Invitation search API' do
       create(:invitation, project: project_three, profile_id: 1, status: :accepted)
       create(:invitation, project: project_three, profile_id: 15, status: :pending)
 
-      get api_v1_invitations_path(params: { id: 1 })
+      get api_v1_invitations_path(params: { profile_id: 1 })
 
       expect(response).to have_http_status :ok
       expect(response.content_type).to include('application/json')
@@ -43,7 +43,7 @@ describe 'Invitation search API' do
     end
 
     it 'retorna vazio quando não existem convites para o usuário' do
-      get api_v1_invitations_path(params: { id: 1 })
+      get api_v1_invitations_path(params: { profile_id: 1 })
 
       expect(response).to have_http_status :ok
       expect(response.content_type).to include 'application/json'
@@ -54,7 +54,7 @@ describe 'Invitation search API' do
     it 'falha quando ocorre erro interno' do
       allow(Invitation).to receive(:pending).and_raise(ActiveRecord::QueryCanceled)
 
-      get api_v1_invitations_path(params: { id: 1 })
+      get api_v1_invitations_path(params: { profile_id: 1 })
 
       expect(response).to have_http_status(:internal_server_error)
     end


### PR DESCRIPTION
# Alcançamos com este PR

Este PR resolve a issue #49

Alteramos o nome do parâmetro recebido na url para busca de convites por perfil de id para profile_id, para não gerar confusão entre o id do convite e o id do perfil consultado. Esta foi uma sugestão do cliente na última apresentação.

Exemplo:
- Antes: `/api/v1/invitations?id=1`
- Depois: `/api/v1/invitations?profile_id=1`

### Print do resultado

![image](https://github.com/TreinaDev/td11-cola-bora/assets/31516900/8d47fbaa-a9ff-4a3f-84da-4b6ea6b1e6e2)
