### PR TITLE
Líder gerencia papéis de membros do projeto

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -36,9 +36,9 @@ class ProjectsController < ApplicationController
   def members
     query = params[:query]
 
-    @leader = @project.leader if query.blank? || query == 'leader'
-    @admins = @project.admins if query.blank? || query == 'admin'
-    @contributors = @project.contributors if query.blank? || query == 'contributor'
+    @leader = @project.member_roles(:leader).first.user if query.blank? || query == 'leader'
+    @admin_roles = @project.member_roles(:admin) if query.blank? || query == 'admin'
+    @contributor_roles = @project.member_roles(:contributor) if query.blank? || query == 'contributor'
   end
 
   private

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,0 +1,21 @@
+class UserRolesController < ApplicationController
+  before_action :set_project, only: %i[edit update]
+  before_action :set_user_role, only: %i[edit update]
+
+  def edit; end
+
+  def update
+    @user_role.admin!
+    redirect_to members_project_path(@project), notice: 'Colaborador atualizado com sucesso'
+  end
+
+  private
+
+  def set_project
+    @project = Project.find(params[:project_id])
+  end
+
+  def set_user_role
+    @user_role = UserRole.find(params[:id])
+  end
+end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -5,9 +5,14 @@ class UserRolesController < ApplicationController
   def edit; end
 
   def update
-    return unless @user_role.update(role: params[:user_role][:role])
+    return redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
 
-    redirect_to members_project_path(@project), notice: t('.success')
+    if sanitized_role && @user_role.update(role: sanitized_role)
+      redirect_to members_project_path(@project), notice: t('.success')
+    else
+      flash.now[:alert] = t('.fail')
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
@@ -18,5 +23,13 @@ class UserRolesController < ApplicationController
 
   def set_user_role
     @user_role = UserRole.find(params[:id])
+    return redirect_to root_path if @user_role.leader?
+
+    @user_role
+  end
+
+  def sanitized_role
+    role = params[:user_role][:role]
+    role if %w[admin contributor].include?(role)
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -6,7 +6,7 @@ class UserRolesController < ApplicationController
 
   def update
     @user_role.admin!
-    redirect_to members_project_path(@project), notice: 'Colaborador atualizado com sucesso'
+    redirect_to members_project_path(@project), notice: t('.success')
   end
 
   private

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,12 +1,11 @@
 class UserRolesController < ApplicationController
   before_action :set_project, only: %i[edit update]
   before_action :set_user_role, only: %i[edit update]
+  before_action :authorize_leader, only: %i[edit update]
 
   def edit; end
 
   def update
-    return redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
-
     if sanitized_role && @user_role.update(role: sanitized_role)
       redirect_to members_project_path(@project), notice: t('.success')
     else
@@ -31,5 +30,9 @@ class UserRolesController < ApplicationController
   def sanitized_role
     role = params[:user_role][:role]
     role if %w[admin contributor].include?(role)
+  end
+
+  def authorize_leader
+    redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,6 +1,7 @@
 class UserRolesController < ApplicationController
   before_action :set_project, only: %i[edit update]
   before_action :set_user_role, only: %i[edit update]
+  before_action :redirect_if_role_is_leader, only: %i[edit update]
   before_action :authorize_leader, only: %i[edit update]
 
   def edit; end
@@ -22,17 +23,18 @@ class UserRolesController < ApplicationController
 
   def set_user_role
     @user_role = UserRole.find(params[:id])
-    return redirect_to root_path if @user_role.leader?
+  end
 
-    @user_role
+  def redirect_if_role_is_leader
+    redirect_to root_path if @user_role.leader?
+  end
+
+  def authorize_leader
+    redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
   end
 
   def sanitized_role
     role = params[:user_role][:role]
     role if %w[admin contributor].include?(role)
-  end
-
-  def authorize_leader
-    redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -5,7 +5,8 @@ class UserRolesController < ApplicationController
   def edit; end
 
   def update
-    @user_role.admin!
+    return unless @user_role.update(role: params[:user_role][:role])
+
     redirect_to members_project_path(@project), notice: t('.success')
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,13 +29,11 @@ class Project < ApplicationRecord
   def admins
     user_roles.where(role: :admin)
               .includes(:user)
-              .map(&:user)
   end
 
   def contributors
     user_roles.where(role: :contributor)
               .includes(:user)
-              .map(&:user)
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,18 +22,10 @@ class Project < ApplicationRecord
     member?(user) && user_roles.find_by(user:).leader?
   end
 
-  def leader
-    user_roles.find_by(role: :leader).user
-  end
+  def member_roles(role)
+    return unless UserRole.roles.keys.include? role.to_s
 
-  def admins
-    user_roles.where(role: :admin)
-              .includes(:user)
-  end
-
-  def contributors
-    user_roles.where(role: :contributor)
-              .includes(:user)
+    user_roles.where(role:).includes(:user)
   end
 
   private

--- a/app/views/projects/_members_table.html.erb
+++ b/app/views/projects/_members_table.html.erb
@@ -50,8 +50,8 @@
         <td><%= admin.user.email %></td>
         <td><%= UserRole.human_attribute_name 'role.admin' %></td>
         <% if project.leader? current_user %>
-          <td><%= link_to t(:manage_member_btn), 
-                          root_path, 
+          <td><%= link_to t(:manage_member_btn),
+                          edit_project_user_role_path(project, admin),
                           class: 'btn btn-sm btn-outline-primary' %></td>
         <% end %>
       </tr>

--- a/app/views/projects/_members_table.html.erb
+++ b/app/views/projects/_members_table.html.erb
@@ -46,7 +46,7 @@
       </tr>
     <% end %>
 
-    <% @admins&.each do |admin| %>
+    <% @admin_roles&.each do |admin| %>
       <tr id="<%= dom_id admin %>_row" class="table-secondary">
         <td><%= admin.user.full_name %></td>
         <td><%= admin.user.email %></td>
@@ -59,7 +59,7 @@
       </tr>
     <% end %>
 
-    <% @contributors&.each do |contributor| %>
+    <% @contributor_roles&.each do |contributor| %>
       <tr id="<%= dom_id contributor %>_row" class="table-light">
         <td><%= contributor.user.full_name %></td>
         <td><%= contributor.user.email %></td>

--- a/app/views/projects/_members_table.html.erb
+++ b/app/views/projects/_members_table.html.erb
@@ -1,17 +1,17 @@
 <%= form_with url: members_project_path(project),
-              class: "d-flex row justify-content-end mb-3", 
+              class: "d-flex row justify-content-end mb-3",
               id: "filter-form",
               method: :get do |f| %>
   <div class="d-flex col-3 gap-2">
     <%= f.label :query,
                 class: 'd-none' %>
-    <%= f.select :query, 
+    <%= f.select :query,
                  [[UserRole.human_attribute_name('role.leader'), :leader],
                   [UserRole.human_attribute_name('role.admin', count: 2), :admin],
-                  [UserRole.human_attribute_name('role.contributor', count: 2), :contributor]], 
-                 { include_blank: t(:all), selected: params[:query] }, 
+                  [UserRole.human_attribute_name('role.contributor', count: 2), :contributor]],
+                 { include_blank: t(:all), selected: params[:query] },
                  { class: 'form-select form-select-sm' } %>
-    <%= f.submit t(:filter_btn), 
+    <%= f.submit t(:filter_btn),
                   class: 'btn btn-sm btn-outline-secondary' %>
   </div>
 <% end %>
@@ -22,6 +22,9 @@
       <th><%= t(:full_name) %></th>
       <th><%= User.human_attribute_name :email %></th>
       <th><%= UserRole.human_attribute_name :role %></th>
+      <% if project.leader? current_user %>
+        <th><%= t(:actions) %></th>
+      <% end %>
     </tr>
   </thead>
 
@@ -37,22 +40,33 @@
         <td><%= @leader.full_name %></td>
         <td><%= @leader.email %></td>
         <td><%= UserRole.human_attribute_name 'role.leader' %></td>
+        <td></td>
       </tr>
     <% end %>
 
     <% @admins&.each do |admin| %>
-      <tr class="table-secondary">
-        <td><%= admin.full_name %></td>
-        <td><%= admin.email %></td>
+      <tr id="<%= dom_id admin %>_row" class="table-secondary">
+        <td><%= admin.user.full_name %></td>
+        <td><%= admin.user.email %></td>
         <td><%= UserRole.human_attribute_name 'role.admin' %></td>
+        <% if project.leader? current_user %>
+          <td><%= link_to t(:manage_member_btn), 
+                          root_path, 
+                          class: 'btn btn-sm btn-outline-primary' %></td>
+        <% end %>
       </tr>
     <% end %>
 
     <% @contributors&.each do |contributor| %>
-      <tr class="table-light">
-        <td><%= contributor.full_name %></td>
-        <td><%= contributor.email %></td>
+      <tr id="<%= dom_id contributor %>_row" class="table-light">
+        <td><%= contributor.user.full_name %></td>
+        <td><%= contributor.user.email %></td>
         <td><%= UserRole.human_attribute_name 'role.contributor' %></td>
+        <% if project.leader? current_user %>
+          <td><%= link_to t(:manage_member_btn),
+                          edit_project_user_role_path(project, contributor),
+                          class: 'btn btn-sm btn-outline-primary' %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/projects/_members_table.html.erb
+++ b/app/views/projects/_members_table.html.erb
@@ -40,7 +40,9 @@
         <td><%= @leader.full_name %></td>
         <td><%= @leader.email %></td>
         <td><%= UserRole.human_attribute_name 'role.leader' %></td>
-        <td></td>
+        <% if project.leader? current_user %>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
 

--- a/app/views/shared/_project_header.html.erb
+++ b/app/views/shared/_project_header.html.erb
@@ -4,29 +4,30 @@
 
 <div class="nav-scroller py-1 mb-3 border-bottom">
   <nav id="project-navbar" class="nav nav-underline">
-    <%= link_to I18n.t(:details), 
-                project_path(project), 
-                class: "nav-item nav-link link-body-emphasis 
+    <%= link_to I18n.t(:details),
+                project_path(project),
+                class: "nav-item nav-link link-body-emphasis
                         #{'active' if current_page?(project_path(project))}" %>
-    <%= link_to Task.model_name.human.pluralize, 
-                project_tasks_path(project), 
-                class: "nav-item nav-link link-body-emphasis 
+    <%= link_to Task.model_name.human.pluralize,
+                project_tasks_path(project),
+                class: "nav-item nav-link link-body-emphasis
                         #{'active' if request.path.include?('/tasks')}" %>
-    <%= link_to Meeting.model_name.human(count: 2), 
-                project_meetings_path(project), 
-                class: "nav-item nav-link link-body-emphasis 
+    <%= link_to Meeting.model_name.human(count: 2),
+                project_meetings_path(project),
+                class: "nav-item nav-link link-body-emphasis
                         #{'active' if request.path.include?('/meeting')}" %>
-    <%= link_to Document.model_name.human(count: 2), 
-                project_documents_path(project), 
-                class: "nav-item nav-link link-body-emphasis 
+    <%= link_to Document.model_name.human(count: 2),
+                project_documents_path(project),
+                class: "nav-item nav-link link-body-emphasis
                         #{'active' if request.path.include?('/documents')}" %>
     <%= link_to t(:members), members_project_path(project),
-                class: "nav-item nav-link link-body-emphasis 
-                #{'active' if request.path.include?('/members')}" %>
+                class: "nav-item nav-link link-body-emphasis
+                #{'active' if request.path.include?('/members') ||
+                           request.path.include?('/user_roles') }" %>
     <% if project.leader?(current_user) %>
-      <%= link_to t(:search_users_btn), 
-                  search_project_portfoliorrr_profiles_path(project), 
-                  class: "nav-item nav-link link-body-emphasis 
+      <%= link_to t(:search_users_btn),
+                  search_project_portfoliorrr_profiles_path(project),
+                  class: "nav-item nav-link link-body-emphasis
                           #{'active' if current_page?(search_project_portfoliorrr_profiles_path(project))}" %>
     <% end %>
   </nav>

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [@project, @user_role] do |f| %>
+  <div class="container mt-3 px-0">
+    <div class="d-flex align-items-center justify-content-start gap-5">
+      <div class="text-start">
+        <span class="display-6 fs-4">
+          <%= @user_role.user.full_name %>
+        </span>
+        <br>
+        <span class="text-muted m-0">
+          <%= @user_role.user.email %>
+        </span>
+      </div>
+      <div>
+        <%= f.label :role, 
+                    class: 'd-none' %>
+        <div class="d-flex justify-content-start">
+          <%= f.select :role,
+                       [['Administrador', :admin], ['Contribuidor', :contributor]],
+                       {}, { class: 'form-select' } %>
+          <div>
+            <%= f.submit 'Salvar',
+                          class: 'btn btn-primary ms-2' %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -15,8 +15,9 @@
                     class: 'd-none' %>
         <div class="d-flex justify-content-start">
           <%= f.select :role,
-                       [['Administrador', :admin], ['Contribuidor', :contributor]],
-                       {}, { class: 'form-select' } %>
+                       [[UserRole.human_attribute_name('role.admin'), :admin], 
+                        [UserRole.human_attribute_name('role.contributor'), :contributor]],
+                        {}, { class: 'form-select' } %>
           <div>
             <%= f.submit t(:save), class: 'btn btn-primary ms-2' %>
           </div>

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -18,8 +18,7 @@
                        [['Administrador', :admin], ['Contribuidor', :contributor]],
                        {}, { class: 'form-select' } %>
           <div>
-            <%= f.submit 'Salvar',
-                          class: 'btn btn-primary ms-2' %>
+            <%= f.submit t(:save), class: 'btn btn-primary ms-2' %>
           </div>
         </div>
       </div>

--- a/app/views/user_roles/edit.html.erb
+++ b/app/views/user_roles/edit.html.erb
@@ -1,20 +1,13 @@
 <%= render 'shared/project_header', project: @project %>
 
 <section>
-  <h2>Gerenciamento de Colaborador</h2>
+  <%= render 'form' %>
 
-  <%= form_with model: [@project, @user_role] do |f| %>
-    <div>
-      <%= @user_role.user.full_name %> <%= @user_role.user.email %>
-    </div>
-    <%= f.label :role %>
-    <%= f.select :role, [['Administrador', :admin], ['Contribuidor', :contributor]] %>
-    <%= f.submit 'Salvar' %>
-  <% end %>
+<hr class="text-secondary">
 
   <div class="mt-3">
     <%= link_to t(:back),
                 members_project_path(@project),
-                class: 'btn btn-secondary' %>
+                class: 'btn btn-sm btn-secondary' %>
   </div>
 </section>

--- a/app/views/user_roles/edit.html.erb
+++ b/app/views/user_roles/edit.html.erb
@@ -1,10 +1,20 @@
-<h1>Gerenciamento de Colaborador</h1>
+<%= render 'shared/project_header', project: @project %>
 
-<%= form_with model: [@project, @user_role] do |f| %>
-  <div>
-    <%= @user_role.user.full_name %> <%= @user_role.user.email %>
-  </div>  
-  <%= f.label :role %>
-  <%= f.select :role, [['Administrador', :admin], ['Contribuidor', :contributor]] %>
-  <%= f.submit 'Salvar' %>
-<% end %>
+<section>
+  <h2>Gerenciamento de Colaborador</h2>
+
+  <%= form_with model: [@project, @user_role] do |f| %>
+    <div>
+      <%= @user_role.user.full_name %> <%= @user_role.user.email %>
+    </div>
+    <%= f.label :role %>
+    <%= f.select :role, [['Administrador', :admin], ['Contribuidor', :contributor]] %>
+    <%= f.submit 'Salvar' %>
+  <% end %>
+
+  <div class="mt-3">
+    <%= link_to t(:back),
+                members_project_path(@project),
+                class: 'btn btn-secondary' %>
+  </div>
+</section>

--- a/app/views/user_roles/edit.html.erb
+++ b/app/views/user_roles/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Gerenciamento de Colaborador</h1>
+
+<%= form_with model: [@project, @user_role] do |f| %>
+  <div>
+    <%= @user_role.user.full_name %> <%= @user_role.user.email %>
+  </div>  
+  <%= f.label :role %>
+  <%= f.select :role, [['Administrador', :admin], ['Contribuidor', :contributor]] %>
+  <%= f.submit 'Salvar' %>
+<% end %>

--- a/config/locales/general.pt-BR.yml
+++ b/config/locales/general.pt-BR.yml
@@ -12,3 +12,4 @@ pt-BR:
   try_again_later: Tente novamente mais tarde
   profile: Perfil de %{name}
   profile_not_available: Perfil não disponível
+  save: Salvar

--- a/config/locales/models/user_role.pt-BR.yml
+++ b/config/locales/models/user_role.pt-BR.yml
@@ -22,3 +22,5 @@ pt-BR:
     update:
       success: Colaborador atualizado com sucesso
     fail: Não foi possível completar a requisição
+    
+  member_managing: Gerenciamento de Colaborador

--- a/config/locales/models/user_role.pt-BR.yml
+++ b/config/locales/models/user_role.pt-BR.yml
@@ -21,3 +21,4 @@ pt-BR:
   user_roles:
     update:
       success: Colaborador atualizado com sucesso
+      fail: Não foi possível completar a requisição

--- a/config/locales/models/user_role.pt-BR.yml
+++ b/config/locales/models/user_role.pt-BR.yml
@@ -21,4 +21,4 @@ pt-BR:
   user_roles:
     update:
       success: Colaborador atualizado com sucesso
-      fail: Não foi possível completar a requisição
+    fail: Não foi possível completar a requisição

--- a/config/locales/models/user_role.pt-BR.yml
+++ b/config/locales/models/user_role.pt-BR.yml
@@ -18,3 +18,6 @@ pt-BR:
           one: Contribuidor
           other: Contribuidores
   one_leader: 'aceita apenas 1 líder'
+  user_roles:
+    update:
+      success: Colaborador atualizado com sucesso

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
         end
       end
     end
+
+    resources :user_roles, only: %i[edit update]
   end
 
   resources :tasks, only: %i[show edit update] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_134826) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "documents", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -104,11 +104,11 @@ RSpec.describe Project, type: :model do
 
   context '#set_leader_on_create' do
     it 'só o criador se torna líder' do
-      create(:user, email: 'another_user@mail.com', cpf: '891.586.070-56')
-      leader = create(:user, email: 'leader@email.com')
-      project = create(:project, user: leader)
-      contributor = create(:user, email: 'contributor@mail.com', cpf: '000.000.001-91')
-      project.user_roles.create!(user: contributor, role: :contributor)
+      create :user, email: 'another_user@mail.com', cpf: '891.586.070-56'
+      leader = create :user, email: 'leader@email.com'
+      project = create :project, user: leader
+      contributor = create :user, email: 'contributor@mail.com', cpf: '000.000.001-91'
+      project.user_roles.create! user: contributor, role: :contributor
 
       expect(project.user_roles.count).to eq 2
       expect(project.user_roles.first.role).to eq 'leader'
@@ -118,60 +118,66 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  context '#leader' do
-    it 'retorna o usuário líder do projeto' do
+  context '#member_roles' do
+    it 'retorna um array com o user_role do líder do projeto' do
       leader = create :user
       project = create :project, user: leader
+      leader_role = UserRole.last
 
-      expect(project.leader).to eq leader
+      expect(project.member_roles(:leader)).to eq [leader_role]
+      expect(project.member_roles(:leader).first.user).to eq leader
     end
-  end
 
-  context '#admins' do
     it 'retorna os administradores do projeto como UserRole' do
       leader = create :user
       admin1 = create :user, cpf: '355.203.830-22'
       admin2 = create :user, cpf: '634.329.380-98'
       contributor = create :user, cpf: '440.882.180-27'
       project = create :project, user: leader
-      admin_1_role = create(:user_role, user: admin1, role: :admin, project:)
-      admin_2_role = create(:user_role, user: admin2, role: :admin, project:)
-      contributor_role = create(:user_role, user: contributor, project:)
+      admin_1_role = create :user_role, project:, user: admin1, role: :admin
+      admin_2_role = create :user_role, project:, user: admin2, role: :admin
+      create :user_role, user: contributor, project:, role: :contributor
 
-      expect(project.admins.count).to eq 2
-      expect(project.admins).to include admin_1_role
-      expect(project.admins).to include admin_2_role
-      expect(project.admins).not_to include contributor_role
+      expect(project.member_roles(:admin).count).to eq 2
+      expect(project.member_roles(:admin)).to eq [admin_1_role, admin_2_role]
+      expect(project.member_roles(:admin).first.user).to eq admin1
+      expect(project.member_roles(:admin).last.user).to eq admin2
     end
 
     it 'retorna um array vazio se não houver admins no projeto' do
       project = create :project
 
-      expect(project.admins).to eq []
+      expect(project.member_roles(:admin)).to eq []
     end
-  end
 
-  context '#contributors' do
     it 'retorna os usuários com papel de colaborador' do
       leader = create :user
       project = create :project, user: leader
       admin = create :user, cpf: '355.203.830-22'
       contributor1 = create :user, cpf: '634.329.380-98'
       contributor2 = create :user, cpf: '440.882.180-27'
-      admin_role = create(:user_role, user: admin, role: :admin, project:)
-      contributor_1_role = create(:user_role, user: contributor1, project:)
-      contributor_2_role = create(:user_role, user: contributor2, project:)
+      create :user_role, project:, user: admin, role: :admin
+      contributor_1_role = create :user_role, project:, user: contributor1
+      contributor_2_role = create :user_role, project:, user: contributor2
 
-      expect(project.contributors.count).to eq 2
-      expect(project.contributors).to include contributor_1_role
-      expect(project.contributors).to include contributor_2_role
-      expect(project.contributors).not_to include admin_role
+      expect(project.member_roles(:contributor).count).to eq 2
+      expect(project.member_roles(:contributor)).to eq [contributor_1_role, contributor_2_role]
+      expect(project.member_roles(:contributor).first.user).to eq contributor1
+      expect(project.member_roles(:contributor).last.user).to eq contributor2
     end
 
     it 'retorna um array vazio se não houver colaboradores no projeto' do
       project = create :project
 
-      expect(project.contributors).to eq []
+      expect(project.member_roles(:contributor)).to eq []
+    end
+
+    it 'retorna nil com papel inexistente' do
+      project = create :project
+      admin = create :user, cpf: '355.203.830-22'
+      create :user_role, project:, user: admin, role: :admin
+
+      expect(project.member_roles(:foo)).to eq nil
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -128,21 +128,20 @@ RSpec.describe Project, type: :model do
   end
 
   context '#admins' do
-    it 'retorna os usuários com papel de administrador' do
+    it 'retorna os administradores do projeto como UserRole' do
       leader = create :user
       admin1 = create :user, cpf: '355.203.830-22'
       admin2 = create :user, cpf: '634.329.380-98'
       contributor = create :user, cpf: '440.882.180-27'
       project = create :project, user: leader
-      project.user_roles.create!([{ user: admin1, role: :admin },
-                                  { user: admin2, role: :admin },
-                                  { user: contributor }])
+      admin_1_role = create(:user_role, user: admin1, role: :admin, project:)
+      admin_2_role = create(:user_role, user: admin2, role: :admin, project:)
+      contributor_role = create(:user_role, user: contributor, project:)
 
       expect(project.admins.count).to eq 2
-      expect(project.admins).to include admin1
-      expect(project.admins).to include admin2
-      expect(project.admins).not_to include leader
-      expect(project.admins).not_to include contributor
+      expect(project.admins).to include admin_1_role
+      expect(project.admins).to include admin_2_role
+      expect(project.admins).not_to include contributor_role
     end
 
     it 'retorna um array vazio se não houver admins no projeto' do
@@ -159,15 +158,14 @@ RSpec.describe Project, type: :model do
       admin = create :user, cpf: '355.203.830-22'
       contributor1 = create :user, cpf: '634.329.380-98'
       contributor2 = create :user, cpf: '440.882.180-27'
-      project.user_roles.create!([{ user: admin, role: :admin },
-                                  { user: contributor1 },
-                                  { user: contributor2 }])
+      admin_role = create(:user_role, user: admin, role: :admin, project:)
+      contributor_1_role = create(:user_role, user: contributor1, project:)
+      contributor_2_role = create(:user_role, user: contributor2, project:)
 
       expect(project.contributors.count).to eq 2
-      expect(project.contributors).to include contributor1
-      expect(project.contributors).to include contributor2
-      expect(project.contributors).not_to include leader
-      expect(project.contributors).not_to include admin
+      expect(project.contributors).to include contributor_1_role
+      expect(project.contributors).to include contributor_2_role
+      expect(project.contributors).not_to include admin_role
     end
 
     it 'retorna um array vazio se não houver colaboradores no projeto' do

--- a/spec/requests/user_roles/user_manages_project_roles_spec.rb
+++ b/spec/requests/user_roles/user_manages_project_roles_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+describe 'Usuário gerencia papel de projeto' do
+  context 'do qual é líder' do
+    it 'e muda administrador para contribuidor com sucesso' do
+      leader = create :user
+      project = create :project, user: leader
+      future_contributor = create :user, cpf: '111.863.720-87'
+      future_contributor_role = create(:user_role, user: future_contributor, project:, role: :admin)
+      params = { user_role: { role: :contributor } }
+
+      login_as leader
+      patch(project_user_role_path(project, future_contributor_role), params:)
+
+      expect(response).to redirect_to members_project_path(project)
+      expect(future_contributor_role.reload.role).to eq 'contributor'
+    end
+
+    it 'e muda contribuidor para administrador com sucesso' do
+      leader = create :user
+      project = create :project, user: leader
+      future_admin = create :user, cpf: '111.863.720-87'
+      future_admin_role = create(:user_role, user: future_admin, project:)
+      params = { user_role: { role: :admin } }
+
+      login_as leader
+      patch(project_user_role_path(project, future_admin_role), params:)
+
+      expect(response).to redirect_to members_project_path(project)
+      expect(future_admin_role.reload.role).to eq 'admin'
+    end
+
+    it 'mas não consegue modificar para um role inexistente' do
+      leader = create :user
+      project = create :project, user: leader
+      admin = create :user, cpf: '111.863.720-87'
+      admin_role = create(:user_role, user: admin, project:, role: :admin)
+      params = { user_role: { role: 'foo' } }
+
+      login_as leader
+      patch(project_user_role_path(project, admin_role), params:)
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+      expect(admin_role.reload.role).to eq 'admin'
+    end
+
+    it 'e não consegue transformar outro usuário em líder' do
+      leader = create :user
+      project = create :project, user: leader
+      contributor = create :user, cpf: '111.863.720-87'
+      contributor_role = create(:user_role, user: contributor, project:)
+      params = { user_role: { role: 'leader' } }
+
+      login_as leader
+      patch(project_user_role_path(project, contributor_role), params:)
+
+      expect(response).to have_http_status :unprocessable_entity
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+      expect(contributor_role.reload.role).to eq 'contributor'
+    end
+
+    it 'e não consegue mudar o papel do líder para outro tipo' do
+      leader = create :user
+      project = create :project, user: leader
+      leader_role = UserRole.last
+      params = { user_role: { role: :contributor } }
+
+      login_as leader
+      patch(project_user_role_path(project, leader_role), params:)
+
+      expect(response).to redirect_to root_path
+      expect(leader_role.reload.role).to eq 'leader'
+    end
+  end
+
+  context 'do qual é administrador' do
+    it 'sem sucesso' do
+      project = create :project
+      admin = create :user, cpf: '281.754.920-15'
+      contributor = create :user, cpf: '137.329.810-37'
+      create(:user_role, user: admin, role: :admin, project:)
+      contributor_role = create(:user_role, user: contributor, project:, role: :contributor)
+      params = { user_role: { role: :admin } }
+
+      login_as admin
+      patch(project_user_role_path(project, contributor_role), params:)
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+      expect(contributor_role.reload.role).to eq 'contributor'
+    end
+  end
+
+  context 'do qual é contribuidor' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '281.754.920-15'
+      admin = create :user, cpf: '137.329.810-37'
+      create(:user_role, user: contributor, role: :contributor, project:)
+      admin_role = create(:user_role, user: admin, project:, role: :admin)
+      params = { user_role: { role: :contributor } }
+
+      login_as contributor
+      patch(project_user_role_path(project, admin_role), params:)
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+      expect(admin_role.reload.role).to eq 'admin'
+    end
+  end
+
+  context 'do qual não faz parte' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '281.754.920-15'
+      contributor_role = create(:user_role, user: contributor, project:)
+      non_member = create :user, cpf: '390.698.050-22'
+      params = { user_role: { role: :admin } }
+
+      login_as non_member
+      patch(project_user_role_path(project, contributor_role), params:)
+
+      expect(response).to redirect_to root_path
+      expect(contributor_role.reload.role).to eq 'contributor'
+    end
+  end
+
+  context 'não autenticado' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '985.557.220-39'
+      contributor_role = create(:user_role, user: contributor, project:)
+      params = { user_role: { role: :admin } }
+
+      patch(project_user_role_path(project, contributor_role), params:)
+
+      expect(response).to redirect_to new_user_session_path
+      expect(contributor_role.reload.role).to eq 'contributor'
+    end
+  end
+end

--- a/spec/requests/user_roles/user_manages_project_roles_spec.rb
+++ b/spec/requests/user_roles/user_manages_project_roles_spec.rb
@@ -9,7 +9,7 @@ describe 'Usuário gerencia papel de projeto' do
       future_contributor_role = create(:user_role, user: future_contributor, project:, role: :admin)
       params = { user_role: { role: :contributor } }
 
-      login_as leader
+      login_as leader, scope: :user
       patch(project_user_role_path(project, future_contributor_role), params:)
 
       expect(response).to redirect_to members_project_path(project)
@@ -23,7 +23,7 @@ describe 'Usuário gerencia papel de projeto' do
       future_admin_role = create(:user_role, user: future_admin, project:)
       params = { user_role: { role: :admin } }
 
-      login_as leader
+      login_as leader, scope: :user
       patch(project_user_role_path(project, future_admin_role), params:)
 
       expect(response).to redirect_to members_project_path(project)
@@ -37,7 +37,7 @@ describe 'Usuário gerencia papel de projeto' do
       admin_role = create(:user_role, user: admin, project:, role: :admin)
       params = { user_role: { role: 'foo' } }
 
-      login_as leader
+      login_as leader, scope: :user
       patch(project_user_role_path(project, admin_role), params:)
 
       expect(response).to have_http_status :unprocessable_entity
@@ -52,7 +52,7 @@ describe 'Usuário gerencia papel de projeto' do
       contributor_role = create(:user_role, user: contributor, project:)
       params = { user_role: { role: 'leader' } }
 
-      login_as leader
+      login_as leader, scope: :user
       patch(project_user_role_path(project, contributor_role), params:)
 
       expect(response).to have_http_status :unprocessable_entity
@@ -66,7 +66,7 @@ describe 'Usuário gerencia papel de projeto' do
       leader_role = UserRole.last
       params = { user_role: { role: :contributor } }
 
-      login_as leader
+      login_as leader, scope: :user
       patch(project_user_role_path(project, leader_role), params:)
 
       expect(response).to redirect_to root_path
@@ -83,7 +83,7 @@ describe 'Usuário gerencia papel de projeto' do
       contributor_role = create(:user_role, user: contributor, project:, role: :contributor)
       params = { user_role: { role: :admin } }
 
-      login_as admin
+      login_as admin, scope: :user
       patch(project_user_role_path(project, contributor_role), params:)
 
       expect(response).to redirect_to root_path
@@ -101,7 +101,7 @@ describe 'Usuário gerencia papel de projeto' do
       admin_role = create(:user_role, user: admin, project:, role: :admin)
       params = { user_role: { role: :contributor } }
 
-      login_as contributor
+      login_as contributor, scope: :user
       patch(project_user_role_path(project, admin_role), params:)
 
       expect(response).to redirect_to root_path
@@ -118,7 +118,7 @@ describe 'Usuário gerencia papel de projeto' do
       non_member = create :user, cpf: '390.698.050-22'
       params = { user_role: { role: :admin } }
 
-      login_as non_member
+      login_as non_member, scope: :user
       patch(project_user_role_path(project, contributor_role), params:)
 
       expect(response).to redirect_to root_path

--- a/spec/requests/user_roles/user_manages_project_roles_spec.rb
+++ b/spec/requests/user_roles/user_manages_project_roles_spec.rb
@@ -6,7 +6,7 @@ describe 'Usuário gerencia papel de projeto' do
       leader = create :user
       project = create :project, user: leader
       future_contributor = create :user, cpf: '111.863.720-87'
-      future_contributor_role = create(:user_role, user: future_contributor, project:, role: :admin)
+      future_contributor_role = create :user_role, user: future_contributor, project:, role: :admin
       params = { user_role: { role: :contributor } }
 
       login_as leader, scope: :user
@@ -20,7 +20,7 @@ describe 'Usuário gerencia papel de projeto' do
       leader = create :user
       project = create :project, user: leader
       future_admin = create :user, cpf: '111.863.720-87'
-      future_admin_role = create(:user_role, user: future_admin, project:)
+      future_admin_role = create :user_role, project:, user: future_admin, role: :contributor
       params = { user_role: { role: :admin } }
 
       login_as leader, scope: :user
@@ -30,11 +30,11 @@ describe 'Usuário gerencia papel de projeto' do
       expect(future_admin_role.reload.role).to eq 'admin'
     end
 
-    it 'mas não consegue modificar para um role inexistente' do
+    it 'mas não consegue modificar para um papel inexistente' do
       leader = create :user
       project = create :project, user: leader
       admin = create :user, cpf: '111.863.720-87'
-      admin_role = create(:user_role, user: admin, project:, role: :admin)
+      admin_role = create :user_role, user: admin, project:, role: :admin
       params = { user_role: { role: 'foo' } }
 
       login_as leader, scope: :user
@@ -49,7 +49,7 @@ describe 'Usuário gerencia papel de projeto' do
       leader = create :user
       project = create :project, user: leader
       contributor = create :user, cpf: '111.863.720-87'
-      contributor_role = create(:user_role, user: contributor, project:)
+      contributor_role = create :user_role, user: contributor, project:, role: :contributor
       params = { user_role: { role: 'leader' } }
 
       login_as leader, scope: :user
@@ -78,9 +78,9 @@ describe 'Usuário gerencia papel de projeto' do
     it 'sem sucesso' do
       project = create :project
       admin = create :user, cpf: '281.754.920-15'
+      create :user_role, user: admin, project:, role: :admin
       contributor = create :user, cpf: '137.329.810-37'
-      create(:user_role, user: admin, role: :admin, project:)
-      contributor_role = create(:user_role, user: contributor, project:, role: :contributor)
+      contributor_role = create :user_role, user: contributor, project:, role: :contributor
       params = { user_role: { role: :admin } }
 
       login_as admin, scope: :user
@@ -96,9 +96,9 @@ describe 'Usuário gerencia papel de projeto' do
     it 'sem sucesso' do
       project = create :project
       contributor = create :user, cpf: '281.754.920-15'
+      create :user_role, user: contributor, project:, role: :contributor
       admin = create :user, cpf: '137.329.810-37'
-      create(:user_role, user: contributor, role: :contributor, project:)
-      admin_role = create(:user_role, user: admin, project:, role: :admin)
+      admin_role = create :user_role, user: admin, project:, role: :admin
       params = { user_role: { role: :contributor } }
 
       login_as contributor, scope: :user
@@ -114,7 +114,7 @@ describe 'Usuário gerencia papel de projeto' do
     it 'sem sucesso' do
       project = create :project
       contributor = create :user, cpf: '281.754.920-15'
-      contributor_role = create(:user_role, user: contributor, project:)
+      contributor_role = create :user_role, project:, user: contributor, role: :contributor
       non_member = create :user, cpf: '390.698.050-22'
       params = { user_role: { role: :admin } }
 
@@ -130,7 +130,7 @@ describe 'Usuário gerencia papel de projeto' do
     it 'sem sucesso' do
       project = create :project
       contributor = create :user, cpf: '985.557.220-39'
-      contributor_role = create(:user_role, user: contributor, project:)
+      contributor_role = create :user_role, project:, user: contributor, role: :contributor
       params = { user_role: { role: :admin } }
 
       patch(project_user_role_path(project, contributor_role), params:)

--- a/spec/requests/user_roles/user_visits_user_role_edit_page_spec.rb
+++ b/spec/requests/user_roles/user_visits_user_role_edit_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Usuário visita página de edição de papel de um projeto' do
+describe 'Usuário visita página de gerenciamento de papel de um projeto' do
   context 'do qual é líder' do
     it 'com sucesso' do
       leader = create :user
@@ -12,6 +12,17 @@ describe 'Usuário visita página de edição de papel de um projeto' do
       get edit_project_user_role_path(project, admin_role)
 
       expect(response).to have_http_status :ok
+    end
+
+    it 'mas não consegue acessar gerenciamento do líder' do
+      leader = create :user
+      project = create :project, user: leader
+      leader_role = UserRole.last
+
+      login_as leader, scope: :user
+      get edit_project_user_role_path project, leader_role
+
+      expect(response).to redirect_to root_path
     end
   end
 
@@ -55,6 +66,18 @@ describe 'Usuário visita página de edição de papel de um projeto' do
 
       expect(response).to redirect_to root_path
       expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+    end
+  end
+
+  context 'mas não está autenticado' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '461.560.280-48'
+      contributor_role = create :user_role, project:, user: contributor
+
+      get edit_project_user_role_path project, contributor_role
+
+      expect(response).to redirect_to new_user_session_path
     end
   end
 end

--- a/spec/requests/user_roles/user_visits_user_role_edit_page_spec.rb
+++ b/spec/requests/user_roles/user_visits_user_role_edit_page_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'Usuário visita página de edição de papel de um projeto' do
+  context 'do qual é líder' do
+    it 'com sucesso' do
+      leader = create :user
+      project = create :project, user: leader
+      admin = create :user, cpf: '518.642.180-45'
+      admin_role = create :user_role, user: admin, project:, role: :admin
+
+      login_as leader, scope: :user
+      get edit_project_user_role_path(project, admin_role)
+
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  context 'do qual é administrador' do
+    it 'sem sucesso' do
+      project = create :project
+      admin = create :user, cpf: '518.642.180-45'
+      admin_role = create :user_role, project:, user: admin, role: :admin
+
+      login_as admin, scope: :user
+      get edit_project_user_role_path project, admin_role
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+    end
+  end
+
+  context 'do qual é contribuidor' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '111.863.720-87'
+      contributor_role = create :user_role, project:, user: contributor
+
+      login_as contributor, scope: :user
+      get edit_project_user_role_path project, contributor_role
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+    end
+  end
+
+  context 'do qual não é membro' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '461.560.280-48'
+      contributor_role = create :user_role, project:, user: contributor
+      non_member = create :user, cpf: '956.519.400-14'
+
+      login_as non_member, scope: :user
+      get edit_project_user_role_path project, contributor_role
+
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq 'Não foi possível completar a requisição'
+    end
+  end
+end

--- a/spec/system/projects/members_list/user_filters_members_list_spec.rb
+++ b/spec/system/projects/members_list/user_filters_members_list_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 describe 'Colaborador filtra lista de membros' do
   context 'por admins' do
     it 'e vê os administradores do projeto' do
-      leader = create(:user, cpf: '515.185.620-00', email: 'leader@email.com')
-      leader.profile.update!(first_name: 'PH', last_name: 'Meneses')
-      project = create(:project, user: leader)
-      admin1 = create(:user, cpf: '485.836.250-77', email: 'admin1@email.com')
-      admin1.profile.update!(first_name: 'João', last_name: 'Silva')
-      admin2 = create(:user, cpf: '996.596.510-23', email: 'admin2@email.com')
-      admin2.profile.update!(first_name: 'Maria', last_name: 'Costa')
-      contributor = create(:user, cpf: '979.612.040-24', email: 'contribuidor@email.com')
-      contributor.profile.update!(first_name: 'Mateus', last_name: 'Cavedini')
+      leader = create :user, cpf: '515.185.620-00', email: 'leader@email.com'
+      leader.profile.update! first_name: 'PH', last_name: 'Meneses'
+      project = create :project, user: leader
+      admin1 = create :user, cpf: '485.836.250-77', email: 'admin1@email.com'
+      admin1.profile.update! first_name: 'João', last_name: 'Silva'
+      admin2 = create :user, cpf: '996.596.510-23', email: 'admin2@email.com'
+      admin2.profile.update! first_name: 'Maria', last_name: 'Costa'
+      contributor = create :user, cpf: '979.612.040-24', email: 'contribuidor@email.com'
+      contributor.profile.update! first_name: 'Mateus', last_name: 'Cavedini'
       project.user_roles.create([{ user: admin1, role: :admin },
                                  { user: admin2, role: :admin },
                                  { user: contributor }])
 
       login_as contributor, scope: :user
-      visit members_project_path(project)
+      visit members_project_path project
       select 'Administradores', from: :query
       click_on 'Filtrar'
 
@@ -40,9 +40,9 @@ describe 'Colaborador filtra lista de membros' do
     end
 
     it 'e não existem administradores no projeto' do
-      leader = create(:user)
-      project = create(:project, user: leader)
-      contributor = create(:user, cpf: '979.612.040-24')
+      leader = create :user
+      project = create :project, user: leader
+      contributor = create :user, cpf: '979.612.040-24'
       project.user_roles.create!({ user: contributor })
 
       login_as contributor, scope: :user
@@ -50,21 +50,23 @@ describe 'Colaborador filtra lista de membros' do
       select 'Administradores', from: :query
       click_on 'Filtrar'
 
-      expect(page).to have_content 'Nenhum resultado encontrado'
+      within 'table' do
+        expect(page).to have_content 'Nenhum resultado encontrado'
+      end
     end
   end
 
   context 'por contribuidores' do
     it 'e vê os contribuidores do projeto' do
-      leader = create(:user, cpf: '515.185.620-00', email: 'leader@email.com')
-      leader.profile.update!(first_name: 'PH', last_name: 'Meneses')
-      project = create(:project, user: leader)
-      admin = create(:user, cpf: '485.836.250-77', email: 'admin@email.com')
-      admin.profile.update!(first_name: 'João', last_name: 'Silva')
-      contributor = create(:user, cpf: '979.612.040-24', email: 'contribuidor@email.com')
-      contributor.profile.update!(first_name: 'Mateus', last_name: 'Cavedini')
-      contributor2 = create(:user, cpf: '996.596.510-23', email: 'contribuidor2@email.com')
-      contributor2.profile.update!(first_name: 'Maria', last_name: 'Costa')
+      leader = create :user, cpf: '515.185.620-00', email: 'leader@email.com'
+      leader.profile.update! first_name: 'PH', last_name: 'Meneses'
+      project = create :project, user: leader
+      admin = create :user, cpf: '485.836.250-77', email: 'admin@email.com'
+      admin.profile.update! first_name: 'João', last_name: 'Silva'
+      contributor = create :user, cpf: '979.612.040-24', email: 'contribuidor@email.com'
+      contributor.profile.update! first_name: 'Mateus', last_name: 'Cavedini'
+      contributor2 = create :user, cpf: '996.596.510-23', email: 'contribuidor2@email.com'
+      contributor2.profile.update! first_name: 'Maria', last_name: 'Costa'
       project.user_roles.create([{ user: admin, role: :admin },
                                  { user: contributor },
                                  { user: contributor2 }])
@@ -93,9 +95,9 @@ describe 'Colaborador filtra lista de membros' do
     end
 
     it 'e não existem contribuidores no projeto' do
-      leader = create(:user)
-      project = create(:project, user: leader)
-      admin = create(:user, cpf: '979.612.040-24')
+      leader = create :user
+      project = create :project, user: leader
+      admin = create :user, cpf: '979.612.040-24'
       project.user_roles.create!({ user: admin, role: :admin })
 
       login_as admin, scope: :user
@@ -103,20 +105,22 @@ describe 'Colaborador filtra lista de membros' do
       select 'Contribuidores', from: :query
       click_on 'Filtrar'
 
-      expect(page).to have_content 'Nenhum resultado encontrado'
+      within 'table' do
+        expect(page).to have_content 'Nenhum resultado encontrado'
+      end
     end
   end
 
   it 'por líder' do
-    leader = create(:user, cpf: '515.185.620-00', email: 'leader@email.com')
-    leader.profile.update!(first_name: 'PH', last_name: 'Meneses')
-    project = create(:project, user: leader)
-    admin = create(:user, cpf: '485.836.250-77', email: 'admin@email.com')
-    admin.profile.update!(first_name: 'João', last_name: 'Silva')
-    contributor = create(:user, cpf: '979.612.040-24', email: 'contribuidor@email.com')
-    contributor.profile.update!(first_name: 'Mateus', last_name: 'Cavedini')
-    contributor2 = create(:user, cpf: '996.596.510-23', email: 'contribuidor2@email.com')
-    contributor2.profile.update!(first_name: 'Maria', last_name: 'Costa')
+    leader = create :user, cpf: '515.185.620-00', email: 'leader@email.com'
+    leader.profile.update! first_name: 'PH', last_name: 'Meneses'
+    project = create :project, user: leader
+    admin = create :user, cpf: '485.836.250-77', email: 'admin@email.com'
+    admin.profile.update! first_name: 'João', last_name: 'Silva'
+    contributor = create :user, cpf: '979.612.040-24', email: 'contribuidor@email.com'
+    contributor.profile.update! first_name: 'Mateus', last_name: 'Cavedini'
+    contributor2 = create :user, cpf: '996.596.510-23', email: 'contribuidor2@email.com'
+    contributor2.profile.update! first_name: 'Maria', last_name: 'Costa'
     project.user_roles.create([{ user: admin, role: :admin },
                                { user: contributor },
                                { user: contributor2 }])
@@ -144,16 +148,16 @@ describe 'Colaborador filtra lista de membros' do
     end
   end
 
-  it 'e retorna para todos os membros' do
-    leader = create(:user, cpf: '515.185.620-00', email: 'leader@email.com')
-    leader.profile.update!(first_name: 'PH', last_name: 'Meneses')
-    project = create(:project, user: leader)
-    admin1 = create(:user, cpf: '485.836.250-77', email: 'admin1@email.com')
-    admin1.profile.update!(first_name: 'João', last_name: 'Silva')
-    admin2 = create(:user, cpf: '996.596.510-23', email: 'admin2@email.com')
-    admin2.profile.update!(first_name: 'Maria', last_name: 'Costa')
-    contributor = create(:user, cpf: '979.612.040-24', email: 'contribuidor@email.com')
-    contributor.profile.update!(first_name: 'Mateus', last_name: 'Cavedini')
+  it 'e filtra por todos os membros' do
+    leader = create :user, cpf: '515.185.620-00', email: 'leader@email.com'
+    leader.profile.update! first_name: 'PH', last_name: 'Meneses'
+    project = create :project, user: leader
+    admin1 = create :user, cpf: '485.836.250-77', email: 'admin1@email.com'
+    admin1.profile.update! first_name: 'João', last_name: 'Silva'
+    admin2 = create :user, cpf: '996.596.510-23', email: 'admin2@email.com'
+    admin2.profile.update! first_name: 'Maria', last_name: 'Costa'
+    contributor = create :user, cpf: '979.612.040-24', email: 'contribuidor@email.com'
+    contributor.profile.update! first_name: 'Mateus', last_name: 'Cavedini'
     project.user_roles.create([{ user: admin1, role: :admin },
                                { user: admin2, role: :admin },
                                { user: contributor }])

--- a/spec/system/projects/members_list/user_views_members_list_spec.rb
+++ b/spec/system/projects/members_list/user_views_members_list_spec.rb
@@ -30,6 +30,7 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).to have_content 'Nome'
         expect(page).to have_content 'E-mail'
         expect(page).to have_content 'Papel'
+        expect(page).to have_content 'Ações'
       end
       within 'tbody' do
         expect(page).to have_content 'Líder do Projeto'
@@ -45,6 +46,7 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).to have_content 'email_como_nome'
         expect(page).to have_content 'email_como_nome@email.com'
         expect(page).to have_content 'Contribuidor', count: 3
+        expect(page).to have_link 'Gerenciar', count: 4
       end
     end
   end
@@ -74,6 +76,7 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).to have_content 'Nome'
         expect(page).to have_content 'E-mail'
         expect(page).to have_content 'Papel'
+        expect(page).not_to have_content 'Ações'
       end
       within 'tbody' do
         expect(page).to have_content 'Líder do Projeto'
@@ -89,20 +92,8 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).to have_content 'email_como_nome'
         expect(page).to have_content 'email_como_nome@email.com'
         expect(page).to have_content 'Contribuidor', count: 3
+        expect(page).not_to have_link 'Gerenciar'
       end
-    end
-  end
-
-  context 'do qual não participa' do
-    it 'e é redirecionado para home' do
-      project = create(:project)
-      non_member = create(:user, cpf: '723.871.450-70')
-
-      login_as non_member, scope: :user
-      visit members_project_path(project)
-
-      expect(page).to have_current_path root_path
-      expect(page).to have_content 'Você não é um colaborador desse projeto'
     end
   end
 end

--- a/spec/system/projects/members_list/user_views_members_list_spec.rb
+++ b/spec/system/projects/members_list/user_views_members_list_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 describe 'Usuário visualiza lista de colaboradores de um projeto' do
   context 'do qual é líder' do
     it 'a partir da home' do
-      leader = create(:user, email: 'leader@email.com')
-      leader.profile.update!(first_name: 'Líder', last_name: 'do Projeto')
-      project = create(:project, title: 'Projeto de listagem', user: leader)
-      admin = create(:user, cpf: '040.363.060-65', email: 'admin@email.com')
-      admin.profile.update!(first_name: 'Admin', last_name: 'Silva')
-      member1 = create(:user, cpf: '367.767.000-44', email: 'nome_aleatorio@email.com')
-      member1.profile.update!(first_name: 'Nome', last_name: 'Aleatório')
-      member2 = create(:user, cpf: '434.508.190-46', email: 'membro@email.com')
-      member2.profile.update!(first_name: 'Membro', last_name: 'Dois')
-      member3 = create(:user, cpf: '527.181.910-82', email: 'email_como_nome@email.com')
-      member3.profile.update!(first_name: '', last_name: '')
+      leader = create :user, email: 'leader@email.com'
+      leader.profile.update! first_name: 'Líder', last_name: 'do Projeto'
+      project = create :project, title: 'Projeto de listagem', user: leader
+      admin = create :user, cpf: '040.363.060-65', email: 'admin@email.com'
+      admin.profile.update! first_name: 'Admin', last_name: 'Silva'
+      member1 = create :user, cpf: '367.767.000-44', email: 'nome_aleatorio@email.com'
+      member1.profile.update! first_name: 'Nome', last_name: 'Aleatório'
+      member2 = create :user, cpf: '434.508.190-46', email: 'membro@email.com'
+      member2.profile.update! first_name: 'Membro', last_name: 'Dois'
+      member3 = create :user, cpf: '527.181.910-82', email: 'email_como_nome@email.com'
+      member3.profile.update! first_name: '', last_name: ''
       project.user_roles.create([{ user: admin, role: :admin },
                                  { user: member1 },
                                  { user: member2 },
@@ -33,12 +33,15 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).to have_content 'Ações'
       end
       within 'tbody' do
-        expect(page).to have_content 'Líder do Projeto'
-        expect(page).to have_content 'leader@email.com'
-        expect(page).to have_content 'Líder'
+        within '#leader_row' do
+          expect(page).to have_content 'Líder do Projeto'
+          expect(page).to have_content 'leader@email.com'
+          expect(page).to have_content 'Líder'
+          expect(page).not_to have_link 'Gerenciar'
+        end
         expect(page).to have_content 'Admin Silva'
         expect(page).to have_content 'admin@email.com'
-        expect(page).to have_content 'Administrador'
+        expect(page).to have_content 'Administrador', count: 1
         expect(page).to have_content 'Nome Aleatório'
         expect(page).to have_content 'nome_aleatorio@email.com'
         expect(page).to have_content 'Membro Dois'
@@ -53,24 +56,24 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
 
   context 'do qual participa' do
     it 'com sucesso' do
-      leader = create(:user, email: 'leader@email.com')
-      leader.profile.update!(first_name: 'Líder', last_name: 'do Projeto')
-      project = create(:project, title: 'Projeto de listagem', user: leader)
-      admin = create(:user, cpf: '040.363.060-65', email: 'admin@email.com')
-      admin.profile.update!(first_name: 'Admin', last_name: 'Silva')
-      member1 = create(:user, cpf: '367.767.000-44', email: 'nome_aleatorio@email.com')
-      member1.profile.update!(first_name: 'Nome', last_name: 'Aleatório')
-      member2 = create(:user, cpf: '434.508.190-46', email: 'membro@email.com')
-      member2.profile.update!(first_name: 'Membro', last_name: 'Dois')
-      member3 = create(:user, cpf: '527.181.910-82', email: 'email_como_nome@email.com')
-      member3.profile.update!(first_name: '', last_name: '')
+      leader = create :user, email: 'leader@email.com'
+      leader.profile.update! first_name: 'Mestre', last_name: 'do Projeto'
+      project = create :project, title: 'Projeto de listagem', user: leader
+      admin = create :user, cpf: '040.363.060-65', email: 'admin@email.com'
+      admin.profile.update! first_name: 'Admin', last_name: 'Silva'
+      member1 = create :user, cpf: '367.767.000-44', email: 'nome_aleatorio@email.com'
+      member1.profile.update! first_name: 'Nome', last_name: 'Aleatório'
+      member2 = create :user, cpf: '434.508.190-46', email: 'membro@email.com'
+      member2.profile.update! first_name: 'Membro', last_name: 'Dois'
+      member3 = create :user, cpf: '527.181.910-82', email: 'email_como_nome@email.com'
+      member3.profile.update! first_name: '', last_name: ''
       project.user_roles.create([{ user: admin, role: :admin },
                                  { user: member1 },
                                  { user: member2 },
                                  { user: member3 }])
 
       login_as member1, scope: :user
-      visit members_project_path(project)
+      visit members_project_path project
 
       within 'thead' do
         expect(page).to have_content 'Nome'
@@ -79,12 +82,12 @@ describe 'Usuário visualiza lista de colaboradores de um projeto' do
         expect(page).not_to have_content 'Ações'
       end
       within 'tbody' do
-        expect(page).to have_content 'Líder do Projeto'
+        expect(page).to have_content 'Mestre do Projeto'
         expect(page).to have_content 'leader@email.com'
-        expect(page).to have_content 'Líder'
+        expect(page).to have_content 'Líder', count: 1
         expect(page).to have_content 'Admin Silva'
         expect(page).to have_content 'admin@email.com'
-        expect(page).to have_content 'Administrador'
+        expect(page).to have_content 'Administrador', count: 1
         expect(page).to have_content 'Nome Aleatório'
         expect(page).to have_content 'nome_aleatorio@email.com'
         expect(page).to have_content 'Membro Dois'

--- a/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
+++ b/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-describe 'Líder gerencia papéis de projeto' do
+describe 'Líder gerencia papel de usuário' do
   context 'com sucesso' do
-    it 'a partir da home' do
+    it 'de contribuidor para administrador' do
       leader = create :user
-      project = create :project, user: leader, title: 'Gerenciamento de Usuários'
+      project = create :project, user: leader
       future_admin = create :user, cpf: '010.124.800-89'
       contributor = create :user, cpf: '186.991.930-09'
       future_admin_role = create(:user_role, user: future_admin, project:)
@@ -23,6 +23,7 @@ describe 'Líder gerencia papéis de projeto' do
       expect(page).to have_content 'Colaborador atualizado com sucesso'
       within "#user_role_#{future_admin_role.reload.id}_row" do
         expect(page).to have_content 'Administrador'
+        expect(page).not_to have_content 'Contribuidor'
       end
       within "#user_role_#{contributor_role.id}_row" do
         expect(page).to have_content 'Contribuidor'
@@ -31,6 +32,38 @@ describe 'Líder gerencia papéis de projeto' do
       expect(project.admins).not_to include contributor_role
       expect(project.contributors).not_to include future_admin_role
       expect(project.contributors).to include contributor_role
+    end
+
+    it 'de administrador para contribuidor' do
+      leader = create :user
+      project = create :project, user: leader, title: 'Gerenciamento de Usuários'
+      future_contributor = create :user, cpf: '010.124.800-89'
+      admin = create :user, cpf: '186.991.930-09'
+      future_contributor_role = create(:user_role, user: future_contributor,
+                                                   project:, role: :admin)
+      admin_role = create(:user_role, user: admin, project:, role: :admin)
+
+      login_as leader, scope: :user
+      visit members_project_path project
+      within "#user_role_#{future_contributor_role.reload.id}_row" do
+        click_on 'Gerenciar'
+      end
+      select 'Contribuidor', from: 'user_role_role'
+      click_on 'Salvar'
+
+      expect(page).to have_current_path members_project_path(project)
+      expect(page).to have_content 'Colaborador atualizado com sucesso'
+      within "#user_role_#{future_contributor_role.reload.id}_row" do
+        expect(page).to have_content 'Contribuidor'
+        expect(page).not_to have_content 'Administrador'
+      end
+      within "#user_role_#{admin_role.id}_row" do
+        expect(page).to have_content 'Administrador'
+      end
+      expect(project.reload.contributors).to include future_contributor_role
+      expect(project.contributors).not_to include admin_role
+      expect(project.admins).not_to include future_contributor_role
+      expect(project.admins).to include admin_role
     end
   end
 end

--- a/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
+++ b/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Líder gerencia papéis de projeto' do
+  context 'com sucesso' do
+    it 'a partir da home' do
+      leader = create :user
+      project = create :project, user: leader, title: 'Gerenciamento de Usuários'
+      future_admin = create :user, cpf: '010.124.800-89'
+      contributor = create :user, cpf: '186.991.930-09'
+      future_admin_role = create(:user_role, user: future_admin, project:)
+      contributor_role = create(:user_role, user: contributor, project:)
+
+      login_as leader, scope: :user
+      visit project_path(project)
+      click_on 'Colaboradores'
+      within "#user_role_#{future_admin_role.id}_row" do
+        click_on 'Gerenciar'
+      end
+      select 'Administrador', from: 'user_role_role'
+      click_on 'Salvar'
+
+      expect(page).to have_current_path members_project_path(project)
+      expect(page).to have_content 'Colaborador atualizado com sucesso'
+      within "#user_role_#{future_admin_role.reload.id}_row" do
+        expect(page).to have_content 'Administrador'
+      end
+      within "#user_role_#{contributor_role.id}_row" do
+        expect(page).to have_content 'Contribuidor'
+      end
+      expect(project.reload.admins).to include future_admin_role
+      expect(project.admins).not_to include contributor_role
+      expect(project.contributors).not_to include future_admin_role
+      expect(project.contributors).to include contributor_role
+    end
+  end
+end

--- a/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
+++ b/spec/system/user_roles/leader_manages_project_user_roles_spec.rb
@@ -28,10 +28,10 @@ describe 'Líder gerencia papel de usuário' do
       within "#user_role_#{contributor_role.id}_row" do
         expect(page).to have_content 'Contribuidor'
       end
-      expect(project.reload.admins).to include future_admin_role
-      expect(project.admins).not_to include contributor_role
-      expect(project.contributors).not_to include future_admin_role
-      expect(project.contributors).to include contributor_role
+      expect(project.reload.member_roles(:admin)).to include future_admin_role
+      expect(project.member_roles(:admin)).not_to include contributor_role
+      expect(project.member_roles(:contributor)).not_to include future_admin_role
+      expect(project.member_roles(:contributor)).to include contributor_role
     end
 
     it 'de administrador para contribuidor' do
@@ -60,10 +60,10 @@ describe 'Líder gerencia papel de usuário' do
       within "#user_role_#{admin_role.id}_row" do
         expect(page).to have_content 'Administrador'
       end
-      expect(project.reload.contributors).to include future_contributor_role
-      expect(project.contributors).not_to include admin_role
-      expect(project.admins).not_to include future_contributor_role
-      expect(project.admins).to include admin_role
+      expect(project.reload.member_roles(:contributor)).to include future_contributor_role
+      expect(project.member_roles(:contributor)).not_to include admin_role
+      expect(project.member_roles(:admin)).not_to include future_contributor_role
+      expect(project.member_roles(:admin)).to include admin_role
     end
   end
 end


### PR DESCRIPTION
# Alcançado com este PR

Este PR fecha a issue #47.


## Gerenciamento de papéis

Um líder de projeto tem acesso a uma coluna de ações na tabela de membros do projeto, por onde ele acessa um formulário que gerencia qual papel um colaborador exerce no projeto.

- Visualização da tabela de membros pelo líder:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/d81a9a7e-7819-4046-9d6a-621ef4582165)

O líder pode gerenciar usuários do tipo Administrador e Contribuidor. A linha do líder na tabela nunca exibirá o botão gerenciar pois ele não pode, até a atual implementação do app, modificar seu próprio papel no projeto.

- Formulário de gerenciamento de usuário:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/50751f5c-5a31-4282-a14a-6c1f2b48bdc6)

O formulário permite a seleção da opção Administrador ou Contribuidor. Ao clicar em salvar o membro terá o novo papel no projeto. Um líder pode, portanto, promover um contribuidor a administrador, ou rebaixar um administrador para contribuidor.

Membros que não são líder do projeto não tem acesso à coluna de ações nem ao formulário de gerenciamento.

- Visualização da tabela de colaboradores por um membro não líder:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/7a6feb95-344f-4b6c-8f3a-754ab95354fa)

### Validações

Para garantir a integridade dos papéis do projeto foram implementadas validações que permitem somente ao líder do projeto gerenciar usuários. O papel de líder não pode ser modificado para outro. Além disso foram inseridas validações que impedem que um membro seja promovido ao papel de líder e também que um papel não existente seja atribuido a algum membro.

