### PR TITLE
Adiciona integração de atualização de status de convite entre plataformas

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ rake spec
 
 ## API
 
+- [Documentação da API](api_doc.md)
+
 
 ## Time de desenvolvimento
 

--- a/api_doc.md
+++ b/api_doc.md
@@ -94,7 +94,7 @@ Erro para objeto não encontrado (Status: 404)
 
 ```json
 { 
-  "errors": ["Não é possível alterar convite que não está pendente."]
+  "errors": ["Erro, não encontrado."]
 }
 ```
 

--- a/api_doc.md
+++ b/api_doc.md
@@ -65,6 +65,41 @@ Retorno esperado:
 }
 ```
 
+---
+
+## 1. Mudar status de um convite para cancelado
+
+### Endpoint
+
+```shell
+PATCH /api/v1/invitations/:id
+```
+<br>
+
+Retorno esperado caso a requisição seja bem sucedida. (Status: 200)
+
+<br>
+
+Retorno caso o convite não esteja mais pendente. (Status: 409)
+
+```json
+{ 
+  "message": ["Não é possível alterar convite que não está pendente."]
+}
+```
+
+  ### Erros tratados
+
+Erro para objeto não encontrado (Status: 404)
+
+```json
+{ 
+  "errors": ["Não é possível alterar convite que não está pendente."]
+}
+```
+
+---
+
 ## Observações Gerais
 - Todos os endpoints retornam dados no formato JSON.
 - Em caso de sucesso, a resposta terá o código 200. 

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,12 +1,17 @@
 module Api
   module V1
     class ApiController < ActionController::API
-      rescue_from ActiveRecord::ActiveRecordError, with: :return500
+      rescue_from ActiveRecord::ActiveRecordError, with: :return_internal_server_error
+      rescue_from ActiveRecord::RecordNotFound, with: :return_not_found
 
       protected
 
-      def return500
+      def return_internal_server_error
         render status: :internal_server_error, json: { errors: [I18n.t('server_error')] }
+      end
+
+      def return_not_found
+        render status: :not_found, json: { errors: [I18n.t('not_found')] }
       end
     end
   end

--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -6,6 +6,14 @@ module Api
         render status: :ok, json: set_json
       end
 
+      def update
+        @invitation = Invitation.find(params[:id])
+        return render status: :conflict, json: { message: [I18n.t('invitation.conflict')] } unless @invitation.pending?
+
+        @invitation.declined!
+        render status: :ok, json: {}
+      end
+
       private
 
       def set_json

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -67,6 +67,7 @@ class InvitationsController < ApplicationController
   def post_portfoliorrr_invitation
     return flash[:notice] = t('.success') if InvitationService::PortfoliorrrPost.send(@invitation)
 
+    flash.discard
     flash[:alert] = t('.fail')
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -27,6 +27,7 @@ class InvitationsController < ApplicationController
   def cancel
     @invitation.processing!
     if @invitation.cancelled!
+      InvitationService::PortfoliorrrPatch.send(@invitation, @invitation.status)
       redirect_to project_portfoliorrr_profile_path(@invitation.project, @invitation.profile_id), notice: t('.success')
     else
       @invitation.pending!

--- a/app/controllers/portfoliorrr_profiles_controller.rb
+++ b/app/controllers/portfoliorrr_profiles_controller.rb
@@ -5,7 +5,8 @@ class PortfoliorrrProfilesController < ApplicationController
 
   def show
     @portfoliorrr_profile_id = params[:id].to_i
-    @current_invitation = @project.invitations.find_by(profile_id: @portfoliorrr_profile_id, status: :pending)
+    @current_invitation = @project.invitations.find_by(profile_id: @portfoliorrr_profile_id,
+                                                       status: %i[pending processing])
     @current_invitation&.validate_expiration_days
     @portfoliorrr_profile = PortfoliorrrProfile.find(@portfoliorrr_profile_id)
 

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -1,5 +1,5 @@
 module InvitationService
-  PORTFOLIORRR_BASE_URL = 'http://localhost:8000'.freeze
+  PORTFOLIORRR_BASE_URL = 'http://localhost:3002'.freeze
   PORTFOLIORRR_INVITATION_URL = '/api/v1/invitations/'.freeze
   class PortfoliorrrPost
     def self.send(invitation)
@@ -32,11 +32,12 @@ module InvitationService
         headers = { 'Content-Type': 'application/json' }
         url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}"
 
-        @response = Faraday.post(url, set_json, headers)
+        @response = Faraday.post(url, set_json.to_json, headers)
       end
 
       def post_success
-        @invitation.portfoliorrr_invitation_id = @response.body[:data][:id]
+        response_body = JSON.parse(@response.body, symbolize_names: true)
+        @invitation.portfoliorrr_invitation_id = response_body[:data][:invitation_id]
         @invitation.pending!
         @invitation.save
       end
@@ -53,7 +54,7 @@ module InvitationService
       url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}#{invitation.portfoliorrr_invitation_id}"
       json = { data: { invitation: { status: } } }
 
-      response = Faraday.patch(url, json, headers)
+      response = Faraday.patch(url, json.to_json, headers)
 
       return false unless response.success?
 

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -1,4 +1,6 @@
 module InvitationService
+  PORTFOLIORRR_BASE_URL = 'http://localhost:8000'.freeze
+  PORTFOLIORRR_INVITATION_URL = '/api/v1/invitations/'.freeze
   class PortfoliorrrPost
     def self.send(invitation)
       @invitation = invitation
@@ -28,7 +30,7 @@ module InvitationService
 
       def post_connection
         headers = { 'Content-Type': 'application/json' }
-        url = 'http://localhost:8000/invitations'
+        url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}"
 
         @response = Faraday.post(url, set_json, headers)
       end
@@ -42,6 +44,22 @@ module InvitationService
       def post_fail
         false if @invitation.delete
       end
+    end
+  end
+
+  class PortfoliorrrPatch
+    def self.send(invitation, status)
+      headers = { 'Content-Type': 'application/json' }
+      url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}#{invitation.portfoliorrr_invitation_id}"
+      json = { data: { invitation: { status: } } }
+
+      response = Faraday.patch(url, json, headers)
+
+      return false unless response.success?
+
+      true
+    rescue Faraday::ConnectionFailed
+      false
     end
   end
 end

--- a/app/views/portfoliorrr_profiles/_invitation_form.html.erb
+++ b/app/views/portfoliorrr_profiles/_invitation_form.html.erb
@@ -26,7 +26,7 @@
   <%= button_to I18n.t('invitations.cancel_button'), cancel_invitation_path(current_invitation.id),
                 method: :patch, class: 'btn btn-danger' %>
 <% elsif current_invitation.present? && current_invitation.processing? %>
-  <p><%= I18n.t('invitations.create.success') %></p>
+  <p><%= I18n.t('invitations.create.process') %></p>
 <% else %>
   <%= form_with(model: invitation, url: project_portfoliorrr_profile_invitations_path(project, profile.id), local: true) do |form| %>
     <div class="mb-3">

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -50,7 +50,7 @@
               <h5 class="my-3"><%= t('portfoliorrr_profile.attributes.cover_letter') %></h5>
               <h4 class="mb-4"><%= @portfoliorrr_profile.cover_letter %></h4>
             </div>
-          </div>        
+          </div>
           <div class="card mb-4">
             <div class="card-body text-center">
               <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation, invitation: @invitation, profile: @portfoliorrr_profile, project: @project } %>

--- a/config/locales/api/api.pt-BR.yml
+++ b/config/locales/api/api.pt-BR.yml
@@ -1,2 +1,5 @@
 pt-BR:
   server_error: Erro interno de servidor.
+  not_found: Erro, não encontrado.
+  invitation:
+    conflict: Não é possível alterar convite que não está pendente.

--- a/config/locales/models/invitations.pt-BR.yml
+++ b/config/locales/models/invitations.pt-BR.yml
@@ -16,7 +16,7 @@ pt-BR:
   invitations:
     create:
       success: Convite enviado com sucesso!
-      process: Convite em processamento!
+      process: Convite em processamento.
       fail: Não foi possível convidar o usuário
       pending_invitation: Esse usuário possui convite pendente
     cancel:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :projects, only: %i[index]
-      resources :invitations, only: %i[index]
+      resources :invitations, only: %i[index update]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,8 +58,10 @@ encrenca_project = FactoryBot.create(:project, user: james, title: 'Encrenca em 
 encrenca_project.user_roles.create!([{ user: jessie, role: :admin }])
 
 ash_project = FactoryBot.create(:project, user: ash, title: 'Pousadaria', category: 'Aplicação WEB')
+
 ash_project2 = FactoryBot.create(:project, user: ash, title: 'Portfoliorr', category: 'Aplicação WEB')
 
+ash_project3 = FactoryBot.create(:project, user: ash, title: 'Arrumar a casa', category: 'Organização')
 
 
 first_project_job_category = FactoryBot.create(:project_job_category, project: pokemon_project, job_category_id: 1)
@@ -81,11 +83,6 @@ FactoryBot.create(:task, project: pokemon_project, title:'Parar a equipe rocket'
 FactoryBot.create(:task, project: pokemon_project, title:'Derrotar um Charmander',
                          description: 'Lutar contra outro treinador com um Charmander.',
                          assigned: ash, due_date: 1.week.from_now, author: ash)
-
-
-
-FactoryBot.create(:invitation, project: pokemon_project, profile_id: 1,
-                            expiration_days: 10, status: :pending)
 
 
 
@@ -124,8 +121,16 @@ FactoryBot.create(:meeting, project: pokemon_project, user_role: UserRole.find_b
                             title:'Daily', description:'', datetime: 5.days.from_now, duration: 15,
                             address: 'https://meet.google.com/')
 
+                            
+FactoryBot.create(:invitation, project: pokemon_project, profile_id: 1,
+                               expiration_days: 10, status: :pending)
+
 FactoryBot.create(:invitation, project: ash_project, profile_email: brock.email,
-                               message: 'Adoraria que fizesse parte da minha equipe')
+                               message: 'Adoraria que fizesse parte da minha equipe', status: :pending)
 
 FactoryBot.create(:invitation, project: ash_project2, profile_email: brock.email,
-                               expiration_days: '')
+                               expiration_days: '', status: :pending)
+                               
+FactoryBot.create(:invitation, project: ash_project3, profile_email: brock.email,
+                               expiration_days: '', status: :processing)
+

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     project
     sequence(:profile_id) { |n| n }
     sequence(:profile_email) { |_n| 'invited@email.com' }
+    status { 'pending' }
   end
 end

--- a/spec/requests/api/v1/invitation_decline_api_spec.rb
+++ b/spec/requests/api/v1/invitation_decline_api_spec.rb
@@ -1,15 +1,45 @@
 require 'rails_helper'
 
 describe 'Invitation decline API' do
-  context 'PATCH /api/v1/invitations/1' do
-    xit 'sucesso e status muda para declined' do
-      invitation = create(:invitation)
+  context 'PATCH /api/v1/invitations/:id' do
+    it 'sucesso e status muda para declined' do
+      invitation = create(:invitation, status: :pending)
 
+      patch api_v1_invitation_path(invitation.id)
 
+      expect(response.status).to eq 200
+      expect(invitation.reload.status).to eq 'declined'
     end
 
-    xit 'falha convite não existe' do
+    it 'falha convite não existe' do
+      invitation = create(:invitation, status: :pending)
 
+      patch api_v1_invitation_path(9)
+
+      expect(response.status).to eq 404
+      expect(invitation.reload.status).to eq 'pending'
+    end
+
+    it 'convite não está pendente' do
+      invitation = create(:invitation, status: :cancelled)
+
+      patch api_v1_invitation_path(invitation.id)
+
+      expect(response.status).to eq 409
+      expect(invitation.reload.status).to eq 'cancelled'
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response['message']).to include 'Não é possível alterar convite que não está pendente.'
+    end
+
+    it 'retorna erro interno do servidor' do
+      invitation = create(:invitation, status: :pending)
+      allow(Invitation).to receive(:find).and_raise(ActiveRecord::ActiveRecordError)
+
+      patch api_v1_invitation_path(1)
+
+      expect(response.status).to eq 500
+      expect(invitation.reload.status).to eq 'pending'
     end
   end
 end

--- a/spec/requests/api/v1/invitation_decline_api_spec.rb
+++ b/spec/requests/api/v1/invitation_decline_api_spec.rb
@@ -7,7 +7,7 @@ describe 'Invitation decline API' do
 
       patch api_v1_invitation_path(invitation.id)
 
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(invitation.reload.status).to eq 'declined'
     end
 
@@ -16,7 +16,7 @@ describe 'Invitation decline API' do
 
       patch api_v1_invitation_path(9)
 
-      expect(response.status).to eq 404
+      expect(response).to have_http_status :not_found
       expect(invitation.reload.status).to eq 'pending'
     end
 
@@ -25,7 +25,7 @@ describe 'Invitation decline API' do
 
       patch api_v1_invitation_path(invitation.id)
 
-      expect(response.status).to eq 409
+      expect(response).to have_http_status :conflict
       expect(invitation.reload.status).to eq 'cancelled'
       expect(response.content_type).to include 'application/json'
       json_response = JSON.parse(response.body)
@@ -38,7 +38,7 @@ describe 'Invitation decline API' do
 
       patch api_v1_invitation_path(1)
 
-      expect(response.status).to eq 500
+      expect(response).to have_http_status :internal_server_error
       expect(invitation.reload.status).to eq 'pending'
     end
   end

--- a/spec/requests/api/v1/invitation_decline_api_spec.rb
+++ b/spec/requests/api/v1/invitation_decline_api_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Invitation decline API' do
+  context 'PATCH /api/v1/invitations/1' do
+    xit 'sucesso e status muda para declined' do
+      invitation = create(:invitation)
+
+
+    end
+
+    xit 'falha convite não existe' do
+
+    end
+  end
+end

--- a/spec/services/invitation_service/portfoliorrr_patch_spec.rb
+++ b/spec/services/invitation_service/portfoliorrr_patch_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe InvitationService::PortfoliorrrPatch do
+  context '.send' do
+    it 'verdadeiro quando efetua a requisição e mantém status cancelado' do
+      fake_response = double('faraday_response', status: 200, success?: true)
+      allow(Faraday).to receive(:patch).and_return(fake_response)
+      invitation = create(:invitation, portfoliorrr_invitation_id: 1, status: :cancelled)
+
+      response = InvitationService::PortfoliorrrPatch.send(invitation, invitation.status)
+
+      expect(response).to eq true
+      expect(Invitation.count).to eq 1
+      expect(invitation.reload.status).to eq 'cancelled'
+    end
+
+    it 'falso quando acontece bad request e mantém status cancelado' do
+      fake_response = double('faraday_response', status: 404, success?: false)
+      allow(Faraday).to receive(:post).and_return(fake_response)
+      invitation = create(:invitation, portfoliorrr_invitation_id: 1, status: :cancelled)
+
+      response = InvitationService::PortfoliorrrPatch.send(invitation, invitation.status)
+
+      expect(response).to eq false
+      expect(Invitation.count).to eq 1
+      expect(invitation.reload.status).to eq 'cancelled'
+    end
+
+    it 'falso quando acontece server error e mantém status cancelado' do
+      fake_response = double('faraday_response', status: 500, success?: false)
+      allow(Faraday).to receive(:post).and_return(fake_response)
+      invitation = create(:invitation, portfoliorrr_invitation_id: 1, status: :cancelled)
+
+      response = InvitationService::PortfoliorrrPatch.send(invitation, invitation.status)
+
+      expect(response).to eq false
+      expect(Invitation.count).to eq 1
+      expect(invitation.reload.status).to eq 'cancelled'
+    end
+
+    it 'falso quando não consegue se conectar com a API e mantém status cancelado' do
+      invitation = create(:invitation, portfoliorrr_invitation_id: 1, status: :cancelled)
+
+      response = InvitationService::PortfoliorrrPatch.send(invitation, invitation.status)
+
+      expect(response).to eq false
+      expect(Invitation.count).to eq 1
+      expect(invitation.reload.status).to eq 'cancelled'
+    end
+  end
+end

--- a/spec/services/invitation_service/portfoliorrr_post_spec.rb
+++ b/spec/services/invitation_service/portfoliorrr_post_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe InvitationService::PortfoliorrrPost do
   context '.send' do
     it 'sucesso atualiza o status e o portfoliorrr_invitation_id' do
-      json = { data: { id: 3 } }
-      fake_response = double('faraday_response', status: 200, body: json, success?: true)
+      json = { data: { invitation_id: 3 } }
+      fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
       allow(Faraday).to receive(:post).and_return(fake_response)
       invitation = create(:invitation)
 

--- a/spec/system/invitations/user_send_invitation_spec.rb
+++ b/spec/system/invitations/user_send_invitation_spec.rb
@@ -10,8 +10,8 @@ describe 'Usuário quer enviar convite' do
                                    job_categories: [JobCategory.new(id: 1, name: 'Desenvolvimento')])
     joao.email = 'joao@email.com'
     allow(PortfoliorrrProfile).to receive(:find).with(1).and_return(joao)
-    json = { data: { id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json, success?: true)
+    json = { data: { invitation_id: 3 } }
+    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
     allow(Faraday).to receive(:post).and_return(fake_response)
 
     login_as user
@@ -105,8 +105,8 @@ describe 'Usuário quer enviar convite' do
                                       job_categories: [JobCategory.new(id: 1, name: 'Desenvolvimento')])
     profile.email = 'joao@email.com'
     allow(PortfoliorrrProfile).to receive(:find).with(1).and_return(profile)
-    json = { data: { id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json, success?: true)
+    json = { data: { invitation_id: 3 } }
+    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
     allow(Faraday).to receive(:post).and_return(fake_response)
 
     login_as owner

--- a/spec/system/invitations/user_send_invitation_spec.rb
+++ b/spec/system/invitations/user_send_invitation_spec.rb
@@ -1,30 +1,51 @@
 require 'rails_helper'
 
 describe 'Usuário quer enviar convite' do
-  it 'com sucesso a partir do perfil do usuário da Portfoliorrr' do
-    user = create(:user)
-    project = create(:project, user:, title: 'Meu novo projeto')
-    create(:project, user:, title: 'Segundo projeto')
+  context 'com sucesso' do
+    it 'a partir do perfil do usuário da Portfoliorrr' do
+      user = create(:user)
+      project = create(:project, user:, title: 'Meu novo projeto')
+      create(:project, user:, title: 'Segundo projeto')
 
-    joao = PortfoliorrrProfile.new(id: 1, name: 'João Marcos',
-                                   job_categories: [JobCategory.new(id: 1, name: 'Desenvolvimento')])
-    joao.email = 'joao@email.com'
-    allow(PortfoliorrrProfile).to receive(:find).with(1).and_return(joao)
-    json = { data: { invitation_id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
-    allow(Faraday).to receive(:post).and_return(fake_response)
+      joao = PortfoliorrrProfile.new(id: 1, name: 'João Marcos',
+                                     job_categories: [JobCategory.new(id: 1, name: 'Desenvolvimento')])
+      joao.email = 'joao@email.com'
+      allow(PortfoliorrrProfile).to receive(:find).with(1).and_return(joao)
+      json = { data: { invitation_id: 3 } }
+      fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
+      allow(Faraday).to receive(:post).and_return(fake_response)
 
-    login_as user
-    visit project_portfoliorrr_profile_path(project, joao.id)
-    fill_in 'Prazo de validade (em dias)', with: 10
-    fill_in 'Mensagem', with: 'Adoraria que fizesse parte do meu projeto'
-    click_on 'Enviar convite'
+      login_as user
+      visit project_portfoliorrr_profile_path(project, joao.id)
+      fill_in 'Prazo de validade (em dias)', with: 10
+      fill_in 'Mensagem', with: 'Adoraria que fizesse parte do meu projeto'
+      click_on 'Enviar convite'
 
-    expect(page).to have_content 'Convite enviado com sucesso!'
-    expect(page).to have_content 'Mensagem: Adoraria que fizesse parte do meu projeto'
-    expect(page).to have_content "Validade: #{I18n.l(10.days.from_now.to_date)}"
-    expect(project.invitations.last.profile_email).to eq 'joao@email.com'
-    expect(project.invitations.last.pending?).to eq true
+      expect(page).to have_content 'Convite enviado com sucesso!'
+      expect(page).to have_content 'Mensagem: Adoraria que fizesse parte do meu projeto'
+      expect(page).to have_content "Validade: #{I18n.l(10.days.from_now.to_date)}"
+      expect(project.invitations.last.profile_email).to eq 'joao@email.com'
+      expect(project.invitations.last.pending?).to eq true
+    end
+
+    it 'e vê mensagem de convite em processamento' do
+      user =  create(:user)
+      project = create(:project, user:, title: 'Meu novo projeto')
+      joao = PortfoliorrrProfile.new(id: 1, name: 'João Marcos',
+                                     job_categories: [JobCategory.new(id: 1, name: 'Desenvolvimento')])
+      allow(PortfoliorrrProfile).to receive(:find).with(1).and_return(joao)
+      create(:invitation, project:, profile_id: joao.id, status: :processing)
+
+      login_as user
+      visit project_portfoliorrr_profile_path(project, joao.id)
+
+      expect(page).to have_content 'Convite em processamento.'
+      expect(page).not_to have_content 'Mensagem: Adoraria que fizesse parte do meu projeto'
+      expect(page).not_to have_content "Validade: #{I18n.l(10.days.from_now.to_date)}"
+      expect(page).not_to have_field 'Prazo de validade (em dias)'
+      expect(page).not_to have_field 'Mensagem'
+      expect(project.invitations.last.processing?).to eq true
+    end
   end
 
   it 'mas o usuário da Portfoliorrr já foi convidado para o projeto' do

--- a/spec/system/invitations/user_updates_invitations_status_spec.rb
+++ b/spec/system/invitations/user_updates_invitations_status_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 describe 'Lider revoga convite' do
   it 'e status muda de pendente para cancelado' do
+    invitation_spy = spy(InvitationService::PortfoliorrrPatch)
+    stub_const('InvitationService::PortfoliorrrPatch', invitation_spy)
+    allow(invitation_spy).to receive(:send)
     user = create(:user)
     project = create(:project, user:, title: 'Meu novo projeto')
 
@@ -19,6 +22,7 @@ describe 'Lider revoga convite' do
     expect(page).to have_content 'Convite cancelado!'
     expect(current_path).to eq project_portfoliorrr_profile_path(project, joao.id)
     expect(Invitation.last.cancelled?).to eq true
+    expect(invitation_spy).to have_received(:send)
   end
 
   it 'e vê página com o convite cancelado' do

--- a/spec/system/invitations/user_updates_invitations_status_spec.rb
+++ b/spec/system/invitations/user_updates_invitations_status_spec.rb
@@ -46,8 +46,8 @@ describe 'Lider revoga convite' do
   end
 
   it 'e envia novo convite' do
-    json = { data: { id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json, success?: true)
+    json = { data: { invitation_id: 3 } }
+    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
     allow(Faraday).to receive(:post).and_return(fake_response)
 
     user = create(:user)


### PR DESCRIPTION
## Alcançamos com esse PR

Resolve issue #65 #66 

Criamos um endpoint patch, que atualiza o status para declined, na Colabora para que o usuário da Portfoliorrr possa recusar o convite direto da Portfoliorrr.

Fizemos a lógica do consumo da api patch da Portfoliorrr para sincronizar os status do convite nas duas plataformas quando ele é cancelado na Colabora. 

Também refatoramos alguns testes e views para se adequarem a nova lógica. 

Registramos a documentação necessária da api no api_doc e inserimos um link para a api_doc no README.

### Prints
![image](https://github.com/TreinaDev/td11-cola-bora/assets/105655467/8e273161-b49e-496e-8ce9-0f2efe5edf1d)
