### PR TITLE
Líder remove usuário de um projeto

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -41,8 +41,8 @@ class ProjectsController < ApplicationController
     query = params[:query]
 
     @leader = @project.member_roles(:leader).first.user if query.blank? || query == 'leader'
-    @admin_roles = @project.member_roles(:admin) if query.blank? || query == 'admin'
-    @contributor_roles = @project.member_roles(:contributor) if query.blank? || query == 'contributor'
+    @admins = @project.member_roles(:admin) if query.blank? || query == 'admin'
+    @contributors = @project.member_roles(:contributor) if query.blank? || query == 'contributor'
   end
 
   private

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,7 +1,7 @@
 class UserRolesController < ApplicationController
   before_action :set_project, only: %i[edit update]
   before_action :set_user_role, only: %i[edit update remove]
-  before_action :redirect_if_role_is_leader, only: %i[edit update]
+  before_action :redirect_if_role_is_leader, only: %i[edit update remove]
   before_action :authorize_leader, only: %i[edit update]
 
   def edit; end
@@ -16,9 +16,12 @@ class UserRolesController < ApplicationController
   end
 
   def remove
-    @user_role.update active: false
-
-    redirect_to members_project_path(@user_role.project), notice: t('.success')
+    if @user_role.project.leader? current_user
+      @user_role.update active: false
+      redirect_to members_project_path(@user_role.project), notice: t('.success')
+    else
+      redirect_to root_path, alert: t('.fail')
+    end
   end
 
   private

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,6 +1,6 @@
 class UserRolesController < ApplicationController
   before_action :set_project, only: %i[edit update]
-  before_action :set_user_role, only: %i[edit update]
+  before_action :set_user_role, only: %i[edit update remove]
   before_action :redirect_if_role_is_leader, only: %i[edit update]
   before_action :authorize_leader, only: %i[edit update]
 
@@ -13,6 +13,12 @@ class UserRolesController < ApplicationController
       flash.now[:alert] = t('.fail')
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def remove
+    @user_role.update active: false
+
+    redirect_to members_project_path(@user_role.project), notice: t('.success')
   end
 
   private

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,6 +1,6 @@
 class UserRolesController < ApplicationController
-  before_action :set_project, only: %i[edit update]
   before_action :set_user_role, only: %i[edit update remove]
+  before_action :set_project, only: %i[edit update remove]
   before_action :redirect_if_role_is_leader, only: %i[edit update remove]
   before_action :authorize_leader, only: %i[edit update]
 
@@ -16,18 +16,16 @@ class UserRolesController < ApplicationController
   end
 
   def remove
-    if @user_role.project.leader? current_user
-      @user_role.update active: false
-      redirect_to members_project_path(@user_role.project), notice: t('.success')
-    else
-      redirect_to root_path, alert: t('.fail')
-    end
+    return redirect_to root_path, alert: t('.fail') unless @project.leader? current_user
+
+    @user_role.update active: false
+    redirect_to members_project_path(@project), notice: t('.success')
   end
 
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = Project.find_by(id: params[:project_id]) || @user_role.project
   end
 
   def set_user_role

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -6,6 +6,8 @@ class UserRole < ApplicationRecord
 
   validate :only_one_leader_per_project
 
+  default_scope { where(active: true) }
+
   def self.get_user_role(project, user)
     UserRole.find_by(user:, project:)
   end

--- a/app/views/projects/_members_table.html.erb
+++ b/app/views/projects/_members_table.html.erb
@@ -31,7 +31,7 @@
   <tbody class= "table-group-divider">
     <% if @leader.blank? && @admins.blank? && @contributors.blank? %>
       <tr class="table-warning text-center">
-        <td colspan="3" class="fw-semibold"><%= t(:no_results) %></td>
+        <td colspan="4" class="fw-semibold"><%= t(:no_results) %></td>
       </tr>
     <% end %>
 
@@ -46,7 +46,7 @@
       </tr>
     <% end %>
 
-    <% @admin_roles&.each do |admin| %>
+    <% @admins&.each do |admin| %>
       <tr id="<%= dom_id admin %>_row" class="table-secondary">
         <td><%= admin.user.full_name %></td>
         <td><%= admin.user.email %></td>
@@ -59,7 +59,7 @@
       </tr>
     <% end %>
 
-    <% @contributor_roles&.each do |contributor| %>
+    <% @contributors&.each do |contributor| %>
       <tr id="<%= dom_id contributor %>_row" class="table-light">
         <td><%= contributor.user.full_name %></td>
         <td><%= contributor.user.email %></td>

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -15,8 +15,11 @@
                     class: 'd-none' %>
         <div class="d-flex justify-content-start">
           <%= f.select :role,
-                       [['Administrador', :admin], ['Contribuidor', :contributor]],
-                       {}, { class: 'form-select' } %>
+                       [[UserRole.human_attribute_name('role.admin'), :admin], 
+                        [UserRole.human_attribute_name('role.contributor'), :contributor]],
+                        {}, { class: 'form-select' } %>
+
+                        
           <div >
             <%= f.submit t(:save), class: 'btn btn-primary ms-2' %>
           </div>

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-3 px-0 row align-items-center">
-  <%= form_with model: [@project, @user_role], class: 'col-10' do |f| %>
+  <%= form_with model: [@project, @user_role], class: 'col-9' do |f| %>
     <div class="d-flex align-items-center justify-content-between gap-5">
       <div class="text-start">
         <span class="display-6 fs-4">
@@ -20,12 +20,11 @@
                         {}, { class: 'form-select' } %>
 
             <%= f.submit t(:save), class: 'btn btn-primary ms-2' %>
-          </div>
         </div>
       </div>
     </div>
   <% end %>
-  <div class="col-2 px-0">
+  <div class="col-3 px-0">
     <%= button_to t(:remove_member_btn),
                   remove_user_role_path(@user_role),
                   method: :patch,

--- a/app/views/user_roles/_form.html.erb
+++ b/app/views/user_roles/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_with model: [@project, @user_role] do |f| %>
-  <div class="container mt-3 px-0">
-    <div class="d-flex align-items-center justify-content-start gap-5">
+<div class="container mt-3 px-0 row align-items-center">
+  <%= form_with model: [@project, @user_role], class: 'col-10' do |f| %>
+    <div class="d-flex align-items-center justify-content-between gap-5">
       <div class="text-start">
         <span class="display-6 fs-4">
           <%= @user_role.user.full_name %>
@@ -17,11 +17,18 @@
           <%= f.select :role,
                        [['Administrador', :admin], ['Contribuidor', :contributor]],
                        {}, { class: 'form-select' } %>
-          <div>
+          <div >
             <%= f.submit t(:save), class: 'btn btn-primary ms-2' %>
           </div>
         </div>
       </div>
     </div>
+  <% end %>
+  <div class="col-2 px-0">
+    <%= button_to t(:remove_member_btn),
+                  remove_user_role_path(@user_role),
+                  method: :patch,
+                  data: { turbo_confirm: t(:remove_member_confirmation) },
+                  class: 'btn btn-danger' %>
   </div>
-<% end %>
+</div>

--- a/app/views/user_roles/edit.html.erb
+++ b/app/views/user_roles/edit.html.erb
@@ -3,7 +3,7 @@
 <section>
   <%= render 'form' %>
 
-<hr class="text-secondary">
+  <hr class="text-secondary">
 
   <div class="mt-3">
     <%= link_to t(:back),

--- a/config/locales/models/user_role.pt-BR.yml
+++ b/config/locales/models/user_role.pt-BR.yml
@@ -22,5 +22,9 @@ pt-BR:
     update:
       success: Colaborador atualizado com sucesso
     fail: Não foi possível completar a requisição
+    remove:
+      success: Colaborador removido com sucesso
     
   member_managing: Gerenciamento de Colaborador
+  remove_member_btn: Remover
+  remove_member_confirmation: Deseja remover este colaborador?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
     resources :user_roles, only: %i[edit update]
   end
 
+  resources :user_roles, only: [] do
+    patch :remove, on: :member
+  end
+
   resources :invitations, only: %i[index show] do
     patch 'accept', on: :member
     patch 'decline', on: :member

--- a/db/migrate/20240202193525_add_active_to_user_roles.rb
+++ b/db/migrate/20240202193525_add_active_to_user_roles.rb
@@ -1,0 +1,5 @@
+class AddActiveToUserRoles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_roles, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_01_183656) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_193525) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -145,6 +145,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_01_183656) do
     t.integer "role", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
     t.index ["project_id"], name: "index_user_roles_on_project_id"
     t.index ["user_id"], name: "index_user_roles_on_user_id"
   end

--- a/spec/requests/projects/user_access_project_spec.rb
+++ b/spec/requests/projects/user_access_project_spec.rb
@@ -51,4 +51,20 @@ describe 'Usuário acessa projeto' do
       expect(response).to redirect_to root_path
     end
   end
+
+  context 'após ser removido' do
+    it 'sem sucesso' do
+      project = create :project
+      contributor = create :user, cpf: '000.000.001-91'
+      project.user_roles.create({ project:,
+                                  user: contributor,
+                                  active: false,
+                                  role: :contributor })
+
+      login_as contributor
+      get(project_path(project))
+
+      expect(response).to redirect_to root_path
+    end
+  end
 end

--- a/spec/requests/user_roles/user_removes_project_members_spec.rb
+++ b/spec/requests/user_roles/user_removes_project_members_spec.rb
@@ -35,7 +35,7 @@ describe 'Usuário remove um colaborador de um projeto' do
       admin = create :user, cpf: '111.863.720-87'
       create :user_role, project:, user: admin, role: :admin
       contributor = create :user, cpf: '281.754.920-15'
-      contributor_role = create :user_role, project:, user: contributor, role: :contributor
+      contributor_role = create :user_role, project:, user: contributor, role: :contributor, active: true
 
       login_as admin
       patch remove_user_role_path(contributor_role)
@@ -52,7 +52,7 @@ describe 'Usuário remove um colaborador de um projeto' do
       admin = create :user, cpf: '111.863.720-87'
       admin_role = create :user_role, project:, user: admin, role: :admin
       contributor = create :user, cpf: '281.754.920-15'
-      create :user_role, project:, user: contributor, role: :contributor
+      create :user_role, project:, user: contributor, role: :contributor, active: true
 
       login_as contributor
       patch remove_user_role_path(admin_role)
@@ -68,7 +68,7 @@ describe 'Usuário remove um colaborador de um projeto' do
       non_member = create :user, cpf: '281.754.920-15'
       project = create :project
       admin = create :user, cpf: '111.863.720-87'
-      admin_role = create :user_role, user: admin, project:, role: :admin
+      admin_role = create :user_role, user: admin, project:, role: :admin, active: true
 
       login_as non_member
       patch remove_user_role_path(admin_role)
@@ -82,7 +82,7 @@ describe 'Usuário remove um colaborador de um projeto' do
   it 'sem estar autenticado' do
     project = create :project
     admin = create :user, cpf: '111.863.720-87'
-    admin_role = create :user_role, project:, user: admin, role: :admin
+    admin_role = create :user_role, project:, user: admin, role: :admin, active: true
 
     patch remove_user_role_path(admin_role)
 

--- a/spec/requests/user_roles/user_removes_project_members_spec.rb
+++ b/spec/requests/user_roles/user_removes_project_members_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe 'Usuário remove um colaborador de um projeto' do
+  context 'do qual é líder' do
+    it 'com sucesso' do
+      leader = create :user
+      project = create :project, user: leader
+      admin = create :user, cpf: '111.863.720-87'
+      admin_role = create :user_role, user: admin, project:, role: :admin, active: true
+
+      login_as leader, scope: :user
+      patch remove_user_role_path(admin_role)
+
+      expect(admin_role.reload.active).to be false
+      expect(project.reload.member?(admin)).to be false
+    end
+
+    it 'sem sucesso se tentar remover a si mesmo' do
+      leader = create :user
+      project = create :project, user: leader
+      leader_role = UserRole.last
+
+      login_as leader, scope: :user
+      patch remove_user_role_path(leader_role)
+
+      expect(response).to redirect_to root_path
+      expect(leader_role.reload.active).to be true
+      expect(project.reload.leader?(leader)).to be true
+    end
+  end
+
+  context 'do qual é administrador' do
+    it 'sem sucesso' do
+      project = create :project
+      admin = create :user, cpf: '111.863.720-87'
+      create :user_role, project:, user: admin, role: :admin
+      contributor = create :user, cpf: '281.754.920-15'
+      contributor_role = create :user_role, project:, user: contributor, role: :contributor
+
+      login_as admin
+      patch remove_user_role_path(contributor_role)
+
+      expect(response).to redirect_to root_path
+      expect(contributor_role.reload.active).to be true
+      expect(project.reload.member?(contributor)).to be true
+    end
+  end
+
+  context 'do qual é contribuidor' do
+    it 'sem sucesso' do
+      project = create :project
+      admin = create :user, cpf: '111.863.720-87'
+      admin_role = create :user_role, project:, user: admin, role: :admin
+      contributor = create :user, cpf: '281.754.920-15'
+      create :user_role, project:, user: contributor, role: :contributor
+
+      login_as contributor
+      patch remove_user_role_path(admin_role)
+
+      expect(response).to redirect_to root_path
+      expect(admin_role.reload.active).to be true
+      expect(project.reload.member?(admin)).to be true
+    end
+  end
+
+  context 'do qual não é colaborador' do
+    it 'sem sucesso' do
+      non_member = create :user, cpf: '281.754.920-15'
+      project = create :project
+      admin = create :user, cpf: '111.863.720-87'
+      admin_role = create :user_role, user: admin, project:, role: :admin
+
+      login_as non_member
+      patch remove_user_role_path(admin_role)
+
+      expect(response).to redirect_to root_path
+      expect(admin_role.reload.active).to be true
+      expect(project.reload.member?(admin)).to be true
+    end
+  end
+
+  it 'sem estar autenticado' do
+    project = create :project
+    admin = create :user, cpf: '111.863.720-87'
+    admin_role = create :user_role, project:, user: admin, role: :admin
+
+    patch remove_user_role_path(admin_role)
+
+    expect(response).to redirect_to new_user_session_path
+    expect(admin_role.reload.active).to be true
+    expect(project.reload.member?(admin)).to be true
+  end
+end

--- a/spec/system/projects/members_list/user_filters_members_list_spec.rb
+++ b/spec/system/projects/members_list/user_filters_members_list_spec.rb
@@ -33,6 +33,7 @@ describe 'Colaborador filtra lista de membros' do
         expect(page).not_to have_content 'contribuidor@email.com'
         expect(page).not_to have_content 'Líder'
         expect(page).not_to have_content 'Contribuidor'
+        expect(page).not_to have_content 'Nenhum resultado encontrado'
       end
       within '#filter-form' do
         expect(page).to have_select :query, selected: 'Administradores'
@@ -88,6 +89,7 @@ describe 'Colaborador filtra lista de membros' do
         expect(page).not_to have_content 'leader@email.com'
         expect(page).not_to have_content 'Líder'
         expect(page).not_to have_content 'Administrador'
+        expect(page).not_to have_content 'Nenhum resultado encontrado'
       end
       within '#filter-form' do
         expect(page).to have_select :query, selected: 'Contribuidores'

--- a/spec/system/user_roles/leader_removes_contributor_from_project_spec.rb
+++ b/spec/system/user_roles/leader_removes_contributor_from_project_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Líder de projeto remove colaborador' do
+  it 'com sucesso' do
+    leader = create :user
+    project = create :project, user: leader
+    contributor1 = create :user, cpf: '528.128.410-01', email: 'removido@email.com'
+    contributor_1_role = create :user_role, project:, user: contributor1, role: :contributor
+    contributor2 = create :user, cpf: '346.045.150-50', email: 'sobrevivente@email.com'
+    contributor_2_role = create :user_role, project:, user: contributor2, role: :contributor
+
+    login_as leader, scope: :user
+    visit edit_project_user_role_path project, contributor_1_role
+    accept_confirm('Deseja remover este colaborador?') { click_on 'Remover' }
+
+    expect(page).to have_current_path members_project_path(project)
+    within 'table' do
+      expect(page).not_to have_content 'removido@email.com'
+      expect(page).to have_content 'sobrevivente@email.com'
+    end
+    expect(page).to have_content 'Colaborador removido com sucesso'
+    expect(project.member_roles(:contributor)).not_to include contributor_1_role
+    expect(project.member_roles(:contributor)).to include contributor_2_role
+  end
+end


### PR DESCRIPTION
# Alcançado com este PR

Este PR resolve a issue #46.

O líder tem acesso a um botão para remover colaborador dentro do formulário de edição de papel no projeto.

- Formulário de gerenciamento de usuário:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/bd39a0da-d4ce-4397-97ed-2382d4a7d1fa)

Ao clicar no botão `Remover` uma janela de confirmação aparece na tela

- Confirmação de remoção:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/300d345d-467d-416f-ba43-34361bdca970)

Caso seja confirmado o usuário é removido do projeto e não aparece mais na listagem de colaboradores, além de perder acesso ao projeto como um todo.

Foram adicionados testes de requisição para garantir que somente o líder pode remover colaboradores e que o líder não pode ser removido de um projeto.