### PR TITLE
Adiciona tela de listagem de projetos seccionada

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,10 @@ class ProjectsController < ApplicationController
   before_action :check_contributor, only: %i[show edit destroy members]
 
   def index
-    @projects = Project.where(user_id: current_user)
+    return @projects = current_user.contributing_projects if params[:filter] == 'contributing_projects'
+    return @projects = current_user.my_projects if params[:filter] == 'my_projects'
+
+    @projects = current_user.all_projects
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,18 @@ class User < ApplicationRecord
     meeting.user_role.user == self || user_role.leader? || user_role.admin?
   end
 
+  def all_projects
+    user_roles.map(&:project)
+  end
+
+  def my_projects
+    user_roles.select { |user_role| user_role.project if user_role.role == 'leader' }.map(&:project)
+  end
+
+  def contributing_projects
+    user_roles.select { |user_role| user_role.project unless user_role.role == 'leader' }.map(&:project)
+  end
+
   private
 
   def create_profile

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,12 +1,14 @@
 <h1><%= Project.model_name.human(count: 2) %></h1>
-<div class="nav-scroller py-1 mb-3 border-bottom">
-  <nav class="nav nav-underline">
-    <%= link_to t(:my_projects), projects_path, class: "nav-item nav-link link-body-emphasis active" %>
+<div class="nav-scroller border-bottom mb-4">
+  <nav class="d-flex nav nav-underline">
+    <%= link_to t('all'), projects_path, class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter].blank? }" %>
+    <%= link_to t('my_projects'), projects_path(params: { filter: 'my_projects' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'my_projects'}" %>
+    <%= link_to 'Projetos que colaboro', projects_path(params: { filter: 'contributing_projects' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'contributing_projects'}" %>
   </nav>
 </div>
 <div class="container">
   <div class="row">
-    <% if @projects.any? %>
+    <% if @projects.present? %>
       <% @projects.each do |project| %>
         <div class="col-sm-6 mb-3">
           <div class="card" style="height: 100%">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -3,7 +3,7 @@
   <nav class="d-flex nav nav-underline">
     <%= link_to t('all'), projects_path, class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter].blank? }" %>
     <%= link_to t('my_projects'), projects_path(params: { filter: 'my_projects' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'my_projects'}" %>
-    <%= link_to 'Projetos que colaboro', projects_path(params: { filter: 'contributing_projects' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'contributing_projects'}" %>
+    <%= link_to t('contributing_projects'), projects_path(params: { filter: 'contributing_projects' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'contributing_projects'}" %>
   </nav>
 </div>
 <div class="container">

--- a/config/locales/models/projects.pt-BR.yml
+++ b/config/locales/models/projects.pt-BR.yml
@@ -30,6 +30,7 @@ pt-BR:
   details: Detalhes
   my_projects: Meus projetos
   projects_empty_state: Nenhum projeto.
+  contributing_projects: Projetos que colaboro.
   profile_search_title: '%{project_title} - Recrutamento de colaboradores'
   manage_member_btn: Gerenciar
   members: Colaboradores

--- a/config/locales/models/projects.pt-BR.yml
+++ b/config/locales/models/projects.pt-BR.yml
@@ -28,8 +28,8 @@ pt-BR:
   delete_confirm_message: Deletar projeto?
   search_users_btn: Procurar usuários
   details: Detalhes
-  my_projects: Meus Projetos
-  projects_empty_state: Não existem projetos cadastrados.
+  my_projects: Meus projetos
+  projects_empty_state: Nenhum projeto.
   profile_search_title: '%{project_title} - Recrutamento de colaboradores'
   manage_member_btn: Gerenciar
   members: Colaboradores

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,21 +117,21 @@ RSpec.describe User, type: :model do
       project_non_contributor = create(:project, user: other_user)
       create(:user_role, user:, project: project_contributor, role: :contributor)
 
-      response = user.all_projects
+      result = user.all_projects
 
-      expect(response).to include project_leader
-      expect(response).to include project_contributor
-      expect(response).not_to include project_non_contributor
+      expect(result).to include project_leader
+      expect(result).to include project_contributor
+      expect(result).not_to include project_non_contributor
     end
     it 'retorna vazio se não tiver projetos' do
       user = create(:user)
       other_user = create(:user, cpf: '000.000.001-91')
       project_non_contributor = create(:project, user: other_user)
 
-      response = user.all_projects
+      result = user.all_projects
 
-      expect(response).to eq []
-      expect(response).not_to include project_non_contributor
+      expect(result).to eq []
+      expect(result).not_to include project_non_contributor
     end
   end
 
@@ -144,11 +144,11 @@ RSpec.describe User, type: :model do
       project_non_contributor = create(:project, user: other_user)
       create(:user_role, user:, project: project_contributor, role: :contributor)
 
-      response = user.my_projects
+      result = user.my_projects
 
-      expect(response).to include project_leader
-      expect(response).not_to include project_contributor
-      expect(response).not_to include project_non_contributor
+      expect(result).to include project_leader
+      expect(result).not_to include project_contributor
+      expect(result).not_to include project_non_contributor
     end
     it 'retorna vazio se não tiver projetos' do
       user = create(:user)
@@ -157,11 +157,11 @@ RSpec.describe User, type: :model do
       project_non_contributor = create(:project, user: other_user)
       create(:user_role, user:, project: project_contributor, role: :contributor)
 
-      response = user.my_projects
+      result = user.my_projects
 
-      expect(response).to eq []
-      expect(response).not_to include project_contributor
-      expect(response).not_to include project_non_contributor
+      expect(result).to eq []
+      expect(result).not_to include project_contributor
+      expect(result).not_to include project_non_contributor
     end
   end
 
@@ -174,23 +174,24 @@ RSpec.describe User, type: :model do
       project_non_contributor = create(:project, user: other_user)
       create(:user_role, user:, project: project_contributor, role: :contributor)
 
-      response = user.contributing_projects
+      result = user.contributing_projects
 
-      expect(response).to include project_contributor
-      expect(response).not_to include project_leader
-      expect(response).not_to include project_non_contributor
+      expect(result).to include project_contributor
+      expect(result).not_to include project_leader
+      expect(result).not_to include project_non_contributor
     end
+
     it 'retorna vazio se não tiver projetos' do
       user = create(:user)
       other_user = create(:user, cpf: '000.000.001-91')
       project_leader = create(:project, user:)
       project_non_contributor = create(:project, user: other_user)
 
-      response = user.contributing_projects
+      result = user.contributing_projects
 
-      expect(response).to eq []
-      expect(response).not_to include project_leader
-      expect(response).not_to include project_non_contributor
+      expect(result).to eq []
+      expect(result).not_to include project_leader
+      expect(result).not_to include project_non_contributor
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,4 +107,90 @@ RSpec.describe User, type: :model do
       expect(contributor.can_edit?(meeting)).to eq false
     end
   end
+
+  context '#all_projects' do
+    it 'retorna todos os projetos de um usuário' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_leader = create(:project, user:)
+      project_contributor = create(:project, user: other_user)
+      project_non_contributor = create(:project, user: other_user)
+      create(:user_role, user:, project: project_contributor, role: :contributor)
+
+      response = user.all_projects
+
+      expect(response).to include project_leader
+      expect(response).to include project_contributor
+      expect(response).not_to include project_non_contributor
+    end
+    it 'retorna vazio se não tiver projetos' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_non_contributor = create(:project, user: other_user)
+
+      response = user.all_projects
+
+      expect(response).to eq []
+      expect(response).not_to include project_non_contributor
+    end
+  end
+
+  context '#my_projects' do
+    it 'retorna todos os projetos de um usuário' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_leader = create(:project, user:)
+      project_contributor = create(:project, user: other_user)
+      project_non_contributor = create(:project, user: other_user)
+      create(:user_role, user:, project: project_contributor, role: :contributor)
+
+      response = user.my_projects
+
+      expect(response).to include project_leader
+      expect(response).not_to include project_contributor
+      expect(response).not_to include project_non_contributor
+    end
+    it 'retorna vazio se não tiver projetos' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_contributor = create(:project, user: other_user)
+      project_non_contributor = create(:project, user: other_user)
+      create(:user_role, user:, project: project_contributor, role: :contributor)
+
+      response = user.my_projects
+
+      expect(response).to eq []
+      expect(response).not_to include project_contributor
+      expect(response).not_to include project_non_contributor
+    end
+  end
+
+  context '#contributing_projects' do
+    it 'retorna todos os projetos que é colaborador' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_leader = create(:project, user:)
+      project_contributor = create(:project, user: other_user)
+      project_non_contributor = create(:project, user: other_user)
+      create(:user_role, user:, project: project_contributor, role: :contributor)
+
+      response = user.contributing_projects
+
+      expect(response).to include project_contributor
+      expect(response).not_to include project_leader
+      expect(response).not_to include project_non_contributor
+    end
+    it 'retorna vazio se não tiver projetos' do
+      user = create(:user)
+      other_user = create(:user, cpf: '000.000.001-91')
+      project_leader = create(:project, user:)
+      project_non_contributor = create(:project, user: other_user)
+
+      response = user.contributing_projects
+
+      expect(response).to eq []
+      expect(response).not_to include project_leader
+      expect(response).not_to include project_non_contributor
+    end
+  end
 end

--- a/spec/requests/projects/user_view_list_projects_spec.rb
+++ b/spec/requests/projects/user_view_list_projects_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Usuário vê projetos' do
+  it 'e deve estar autenticado' do
+    get projects_path
+
+    expect(response).to redirect_to new_user_session_path
+    expect(flash[:alert]).to eq 'Para continuar, faça login ou registre-se.'
+  end
+end

--- a/spec/system/projects/user_view_list_projects_spec.rb
+++ b/spec/system/projects/user_view_list_projects_spec.rb
@@ -1,100 +1,137 @@
 require 'rails_helper'
 
-describe 'Usuário vê projetos seus' do
-  it 'e deve estar autenticado' do
-    visit projects_path
-
-    expect(current_path).to eq new_user_session_path
-    expect(page).to have_content 'Para continuar, faça login ou registre-se'
-  end
-
+describe 'Usuário vê projetos' do
   it 'a partir da home com sucesso' do
-    deco = create :user, email: 'deco@email.com'
-    mateus = create :user, email: 'mateus@email.com', cpf: '096.505.460-81'
-    create :project, user: deco, title: 'Padrão', description: 'Descrição de um projeto padrão para testes',
-                     category: 'Teste'
-    create :project, title: 'Criação de site',
-                     description: 'Esse projeto é sobre a criação de um website para a cidade',
-                     category: 'Webdesign', user: deco
-    create :project, title: 'Peça de Teatro', description: 'Espetáculo de Shakespeare', category: 'Teatro', user: mateus
+    leader = create :user
+    other_leader = create :user, cpf: '096.505.460-81'
+    project_one = create :project, user: other_leader, title: 'Capturar todos os pokemons',
+                                   description: 'Descrição do projeto 1', category: 'Categoria 1'
+    project_two = create :project, user: other_leader, title: 'Mestre pokemon',
+                                   description: 'Esse projeto é o mais dificil', category: 'Categoria 2'
+    create :project, user: leader, title: 'Pokedex',
+                     description: 'Projeto interessante!', category: 'Categoria 3'
+    create :project, user: leader, title: 'Pegar um mewtwo',
+                     description: 'Projeto top!', category: 'Categoria 5'
+    create :user_role, project: project_one, user: leader, role: :contributor
+    create :user_role, project: project_two, user: leader, role: :admin
 
-    login_as deco
-    visit root_path
-    click_on 'Projetos'
-
-    expect(page).to have_current_path projects_path
-    expect(page).to have_content 'Padrão'
-    expect(page).to have_content 'Descrição de um projeto padrão para testes'
-    expect(page).to have_content 'Categoria: Teste'
-    expect(page).to have_content 'Criação de site'
-    expect(page).to have_content 'Esse projeto é sobre a criação de um website para a cidade'
-    expect(page).to have_content 'Categoria: Webdesign'
-    expect(page).not_to have_content 'Peça de Teatro'
-    expect(page).not_to have_content 'Espetáculo de Shakespeare'
-    expect(page).not_to have_content 'Categoria: Teatro'
-  end
-
-  it 'e não existe nenhum projeto cadastrado' do
-    deco = create :user, email: 'deco@email.com'
-
-    login_as deco
+    login_as leader
     visit projects_path
 
     expect(page).to have_content 'Projetos'
-    expect(page).to have_content 'Não existem projetos cadastrados.'
+    expect(page).not_to have_content 'Nenhum projeto.'
+    expect(page).to have_content 'Capturar todos os pokemons'
+    expect(page).to have_content 'Descrição do projeto 1'
+    expect(page).to have_content 'Categoria: Categoria 1'
+    expect(page).to have_content 'Mestre pokemon'
+    expect(page).to have_content 'Esse projeto é o mais dificil'
+    expect(page).to have_content 'Categoria: Categoria 2'
+    expect(page).to have_content 'Pokedex'
+    expect(page).to have_content 'Projeto interessante!'
+    expect(page).to have_content 'Categoria: Categoria 3'
   end
 
-  it 'que criou e deve estar autenticado' do
+  it 'e não existe nenhum projeto cadastrado' do
+    user = create :user
+
+    login_as user
     visit projects_path
 
-    expect(current_path).to eq new_user_session_path
-    expect(page).to have_content 'Para continuar, faça login ou registre-se'
+    expect(page).to have_content 'Projetos'
+    expect(page).to have_content 'Nenhum projeto.'
   end
 
-  it 'e vê apenas os projetos que criou' do
-    deco = create :user, email: 'deco@email.com'
-    mateus = create :user, email: 'mateus@email.com', cpf: '096.505.460-81'
-    create :project, user: deco, title: 'Padrão', description: 'Descrição de um projeto padrão para testes',
-                     category: 'Teste'
-    create :project, title: 'Criação de site',
-                     description: 'Esse projeto é sobre a criação de um website para a cidade',
-                     category: 'Webdesign', user: deco
-    create :project, title: 'Peça de Teatro', description: 'Espetáculo de Shakespeare', category: 'Teatro', user: mateus
+  it 'nos quais é lider' do
+    leader = create :user
+    other_leader = create :user, cpf: '096.505.460-81'
+    create :project, user: other_leader, title: 'Capturar todos os pokemons',
+                     description: 'Descrição do projeto 1', category: 'Categoria 1'
+    create :project, user: leader, title: 'Mestre pokemon',
+                     description: 'Esse projeto é o mais dificil', category: 'Categoria 2'
+    create :project, user: leader, title: 'Pokedex',
+                     description: 'Projeto interessante!', category: 'Categoria 3'
 
-    login_as deco
+    login_as leader
     visit projects_path
-    click_on 'Meus Projetos'
+    click_on 'Meus projetos'
 
-    expect(current_path).to eq projects_path
-    expect(page).to have_content 'Padrão'
-    expect(page).to have_content 'Descrição de um projeto padrão para testes'
-    expect(page).to have_content 'Categoria: Teste'
-    expect(page).to have_content 'Criação de site'
-    expect(page).to have_content 'Esse projeto é sobre a criação de um website para a cidade'
-    expect(page).to have_content 'Categoria: Webdesign'
-    expect(page).not_to have_content 'Peça de Teatro'
-    expect(page).not_to have_content 'Espetáculo de Shakespeare'
-    expect(page).not_to have_content 'Categoria: Teatro'
+    expect(page).to have_content 'Projetos'
+    expect(page).not_to have_content 'Nenhum projeto.'
+    expect(page).not_to have_content 'Capturar todos os pokemons'
+    expect(page).to have_content 'Mestre pokemon'
+    expect(page).to have_content 'Esse projeto é o mais dificil'
+    expect(page).to have_content 'Categoria: Categoria 2'
+    expect(page).to have_content 'Pokedex'
+    expect(page).to have_content 'Projeto interessante!'
+    expect(page).to have_content 'Categoria: Categoria 3'
   end
 
-  it 'e não criou nenhum projeto' do
-    deco = create :user, email: 'deco@email.com'
-    mateus = create :user, email: 'mateus@email.com', cpf: '096.505.460-81'
-    create :project, user: deco, title: 'Padrão', description: 'Descrição de um projeto padrão para testes',
-                     category: 'Teste'
-    create :project, title: 'Criação de site',
-                     description: 'Esse projeto é sobre a criação de um website para a cidade',
-                     category: 'Webdesign', user: deco
+  it 'nos quais é lider e não há nenhum projeto' do
+    leader = create :user
+    other_leader = create :user, cpf: '096.505.460-81'
+    create :project, user: other_leader, title: 'Capturar todos os pokemons'
+    create :project, user: other_leader, title: 'Mestre pokemon'
+    create :project, user: other_leader, title: 'Pokedex'
 
-    login_as mateus
+    login_as leader
     visit projects_path
+    click_on 'Meus projetos'
 
-    expect(page).to have_content 'Não existem projetos cadastrados.'
-    expect(page).not_to have_content 'Padrão'
-    expect(page).not_to have_content 'Descrição de um projeto padrão para testes'
-    expect(page).not_to have_content 'Categoria: Teste'
-    expect(page).not_to have_content 'Criação de site'
-    expect(page).not_to have_content 'Esse projeto é sobre a criação de um website para a cidade'
-    expect(page).not_to have_content 'Categoria: Webdesign'
+    expect(page).to have_content 'Projetos'
+    expect(page).to have_content 'Nenhum projeto.'
+    expect(page).not_to have_content 'Capturar todos os pokemons'
+    expect(page).not_to have_content 'Mestre pokemon'
+    expect(page).not_to have_content 'Pokedex'
+  end
+
+  it 'nos quais é colaborador' do
+    leader = create :user
+    contributor = create :user, email: 'contributor@email.com', cpf: '096.505.460-81'
+    project_one = create :project, user: leader, title: 'Capturar todos os pokemons',
+                                   description: 'Descrição do projeto 1', category: 'Categoria 1'
+    project_two = create :project, user: leader, title: 'Mestre pokemon',
+                                   description: 'Esse projeto é o mais dificil', category: 'Categoria 2'
+    project_three = create :project, user: leader, title: 'Pokedex',
+                                     description: 'Projeto interessante!', category: 'Categoria 3'
+    create :user_role, project: project_one, user: contributor, role: :contributor
+    create :user_role, project: project_two, user: contributor, role: :contributor
+    create :user_role, project: project_three, user: contributor, role: :contributor
+
+    login_as contributor
+    visit projects_path
+    click_on 'Projetos que colaboro'
+
+    expect(page).to have_content 'Projetos'
+    expect(page).not_to have_content 'Nenhum projeto.'
+    expect(page).to have_content 'Capturar todos os pokemons'
+    expect(page).to have_content 'Descrição do projeto 1'
+    expect(page).to have_content 'Categoria: Categoria 1'
+    expect(page).to have_content 'Mestre pokemon'
+    expect(page).to have_content 'Esse projeto é o mais dificil'
+    expect(page).to have_content 'Categoria: Categoria 2'
+    expect(page).to have_content 'Pokedex'
+    expect(page).to have_content 'Projeto interessante!'
+    expect(page).to have_content 'Categoria: Categoria 3'
+  end
+
+  it 'nos quais é colaborador e não há nenhum projeto' do
+    leader = create :user
+    contributor = create :user, cpf: '643.770.760-78'
+    project_one = create :project, user: leader, title: 'Capturar todos os pokemons'
+    project_two = create :project, user: leader, title: 'Mestre pokemon'
+    project_three = create :project, user: leader, title: 'Pokedex'
+    create :user_role, project: project_one, user: contributor, role: :contributor
+    create :user_role, project: project_two, user: contributor, role: :contributor
+    create :user_role, project: project_three, user: contributor, role: :contributor
+    not_contributor = create :user, cpf: '096.505.460-81'
+
+    login_as not_contributor
+    visit projects_path
+    click_on 'Projetos que colaboro'
+
+    expect(page).to have_content 'Nenhum projeto.'
+    expect(page).not_to have_content 'Capturar todos os pokemons'
+    expect(page).not_to have_content 'Mestre pokemon'
+    expect(page).not_to have_content 'Pokedex'
   end
 end

--- a/spec/system/projects/user_view_list_projects_spec.rb
+++ b/spec/system/projects/user_view_list_projects_spec.rb
@@ -71,7 +71,6 @@ describe 'Usuário vê projetos' do
     other_leader = create :user, cpf: '096.505.460-81'
     create :project, user: other_leader, title: 'Capturar todos os pokemons'
     create :project, user: other_leader, title: 'Mestre pokemon'
-    create :project, user: other_leader, title: 'Pokedex'
 
     login_as leader
     visit projects_path
@@ -81,7 +80,6 @@ describe 'Usuário vê projetos' do
     expect(page).to have_content 'Nenhum projeto.'
     expect(page).not_to have_content 'Capturar todos os pokemons'
     expect(page).not_to have_content 'Mestre pokemon'
-    expect(page).not_to have_content 'Pokedex'
   end
 
   it 'nos quais é colaborador' do
@@ -91,11 +89,8 @@ describe 'Usuário vê projetos' do
                                    description: 'Descrição do projeto 1', category: 'Categoria 1'
     project_two = create :project, user: leader, title: 'Mestre pokemon',
                                    description: 'Esse projeto é o mais dificil', category: 'Categoria 2'
-    project_three = create :project, user: leader, title: 'Pokedex',
-                                     description: 'Projeto interessante!', category: 'Categoria 3'
     create :user_role, project: project_one, user: contributor, role: :contributor
     create :user_role, project: project_two, user: contributor, role: :contributor
-    create :user_role, project: project_three, user: contributor, role: :contributor
 
     login_as contributor
     visit projects_path
@@ -109,20 +104,13 @@ describe 'Usuário vê projetos' do
     expect(page).to have_content 'Mestre pokemon'
     expect(page).to have_content 'Esse projeto é o mais dificil'
     expect(page).to have_content 'Categoria: Categoria 2'
-    expect(page).to have_content 'Pokedex'
-    expect(page).to have_content 'Projeto interessante!'
-    expect(page).to have_content 'Categoria: Categoria 3'
   end
 
   it 'nos quais é colaborador e não há nenhum projeto' do
     leader = create :user
     contributor = create :user, cpf: '643.770.760-78'
     project_one = create :project, user: leader, title: 'Capturar todos os pokemons'
-    project_two = create :project, user: leader, title: 'Mestre pokemon'
-    project_three = create :project, user: leader, title: 'Pokedex'
     create :user_role, project: project_one, user: contributor, role: :contributor
-    create :user_role, project: project_two, user: contributor, role: :contributor
-    create :user_role, project: project_three, user: contributor, role: :contributor
     not_contributor = create :user, cpf: '096.505.460-81'
 
     login_as not_contributor
@@ -131,7 +119,5 @@ describe 'Usuário vê projetos' do
 
     expect(page).to have_content 'Nenhum projeto.'
     expect(page).not_to have_content 'Capturar todos os pokemons'
-    expect(page).not_to have_content 'Mestre pokemon'
-    expect(page).not_to have_content 'Pokedex'
   end
 end


### PR DESCRIPTION
Resolve #73 

Este PR adiciona duas seções na listagem de projetos:
- `Meus projetos`
- `Projetos que colaboro`

Também refatoramos para, quando o usuário clicar em `Projetos`, a primeira exibição é a de `Todos`.

### Prints

![image](https://github.com/TreinaDev/td11-cola-bora/assets/69739994/640dbdc7-fcee-46fe-b6d3-d58b557ca110)
