### PR TITLE
Fix: atualiza gem nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,9 +177,9 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.0-arm64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.0-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.24.0)


### PR DESCRIPTION
# Autualiza gem nokogiri
Essa PR atualiza a gem Nokigiri para a versão 1.16.2.