### PR TITLE
Líder de projeto aceita solicitação de participação por usuários do Portfoliorrr

### DIFF
--- a/app/controllers/portfoliorrr_profiles_controller.rb
+++ b/app/controllers/portfoliorrr_profiles_controller.rb
@@ -10,6 +10,10 @@ class PortfoliorrrProfilesController < ApplicationController
     @current_invitation&.validate_expiration_days
     @portfoliorrr_profile = PortfoliorrrProfile.find(@portfoliorrr_profile_id)
 
+    unless @current_invitation&.pending? || @current_invitation&.processing?
+      @current_proposal = Proposal.find_by(project: @project, profile_id: @portfoliorrr_profile_id, status: :pending)
+    end
+
     @invitation = Invitation.new
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -43,6 +43,11 @@ class Invitation < ApplicationRecord
     User.find_by(email: profile_email)
   end
 
+  def accept_proposal
+    proposal = Proposal.find_by(project_id:, profile_id:, status: :pending)
+    proposal&.accepted!
+  end
+
   private
 
   def days_to_date

--- a/app/models/portfoliorrr_profile.rb
+++ b/app/models/portfoliorrr_profile.rb
@@ -24,6 +24,7 @@ class PortfoliorrrProfile
     return {} unless response.success?
 
     profile_json = JSON.parse(response.body, symbolize_names: true)[:data]
+
     profile = new_profile(profile_json)
     profile.build_details(profile_json)
   rescue Faraday::ConnectionFailed

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -39,6 +39,7 @@ module InvitationService
         response_body = JSON.parse(@response.body, symbolize_names: true)
         @invitation.portfoliorrr_invitation_id = response_body[:data][:invitation_id]
         @invitation.pending!
+        @invitation.accept_proposal
         @invitation.save
       end
 

--- a/app/views/portfoliorrr_profiles/_invitation_form.html.erb
+++ b/app/views/portfoliorrr_profiles/_invitation_form.html.erb
@@ -1,4 +1,10 @@
-<h3 class="mb-3"><%= t('sending_invitation')%></h3>
+<h3 class="mb-3">
+  <% if current_proposal %>
+    Solicitação pendente
+  <% else %>
+    <%= t('sending_invitation')%>
+  <% end %>
+</h3>
 
 <% if invitation.errors.any? %>
   <div class='text-danger'>
@@ -11,7 +17,7 @@
   </div>
 <% end %>
 
-<% if current_invitation.present? && current_invitation.pending? %>
+<% if current_invitation&.pending? %>
   <p><%= I18n.t('invitations.create.pending_invitation') %></p>
   
   <% unless current_invitation.message.blank? %>
@@ -25,11 +31,10 @@
 
   <%= button_to I18n.t('invitations.cancel_button'), cancel_invitation_path(current_invitation.id),
                 method: :patch, class: 'btn btn-danger' %>
-<% elsif current_invitation.present? && current_invitation.processing? %>
+<% elsif current_invitation&.processing? %>
   <p><%= I18n.t('invitations.create.process') %></p>
 <% else %>
   <% if current_proposal %>
-    <p>Solicitação pendente</p>
     <%= current_proposal.message %>
   <% end %>
 

--- a/app/views/portfoliorrr_profiles/_invitation_form.html.erb
+++ b/app/views/portfoliorrr_profiles/_invitation_form.html.erb
@@ -1,63 +1,83 @@
-<h3 class="mb-3">
-  <% if current_proposal %>
-    Solicitação pendente
-  <% else %>
-    <%= t('sending_invitation')%>
-  <% end %>
-</h3>
-
-<% if invitation.errors.any? %>
-  <div class='text-danger'>
-    <h3><%= I18n.t('.errors_title') %>:</h3>
-    <ul>
-      <% invitation.errors.each do |error| %>
-        <li><%= error.full_message %></li>
+<div class="card mb-4 bg-light shadow">
+  <div class="card-body text-center">
+    <h3 class="mb-3">
+      <% if current_proposal %>
+        <%= t(:new_proposal) %>
+      <% else %>
+        <%= t('sending_invitation')%>
       <% end %>
-    </ul>
-  </div>
-<% end %>
-
-<% if current_invitation&.pending? %>
-  <p><%= I18n.t('invitations.create.pending_invitation') %></p>
-  
-  <% unless current_invitation.message.blank? %>
-    <p><%= Invitation.human_attribute_name :message %>: <%= current_invitation.message  %></p>
-  <% end %>
-
-  <p>
-    <%= Invitation.human_attribute_name :expiration_date %>: 
-    <%= current_invitation.expiration_date ? l(current_invitation.expiration_date) : I18n.t('invitations.no_expiration_date') %>
-  </p>
-
-  <%= button_to I18n.t('invitations.cancel_button'), cancel_invitation_path(current_invitation.id),
-                method: :patch, class: 'btn btn-danger' %>
-<% elsif current_invitation&.processing? %>
-  <p><%= I18n.t('invitations.create.process') %></p>
-<% else %>
-  <% if current_proposal %>
-    <%= current_proposal.message %>
-  <% end %>
-
-  <%= form_with(model: invitation, url: project_portfoliorrr_profile_invitations_path(project, profile.id), local: true) do |form| %>
-    <div class="mb-3">
-      <div class="row">
-        <div class="col-2"></div>
-          <%= form.label :expiration_days, class: 'form-label' %>
-          <%= form.number_field :expiration_days, class: 'form-control', min: 0 %>
-        </div>
-        <div class="col-2"></div>
-          <%= form.label :message, class: 'form-label' %>
-          <%= form.text_area :message, class: 'form-control' %>
-          <%= form.hidden_field :profile_email, value: profile.email %>
-        </div>
-        <div class="d-flex justify-content-center mb-2">
-          <% if current_proposal %>
-            <%= form.submit 'Aceitar', class: 'btn btn-primary' %>
-          <% else %>
-            <%= form.submit I18n.t('invitations.send_invitation'), class: 'btn btn-primary' %>
+    </h3>
+    
+    <% if invitation.errors.any? %>
+      <div class='text-danger'>
+        <h3><%= I18n.t('.errors_title') %>:</h3>
+        <ul>
+          <% invitation.errors.each do |error| %>
+            <li><%= error.full_message %></li>
           <% end %>
-        </div>
+        </ul>
       </div>
-    </div>
-  <% end %>
-<% end %>
+    <% end %>
+
+    <% if current_invitation&.pending? %>
+      <p><%= I18n.t('invitations.create.pending_invitation') %></p>
+      
+      <% unless current_invitation.message.blank? %>
+        <p><%= Invitation.human_attribute_name :message %>: <%= current_invitation.message %></p>
+      <% end %>
+
+      <p>
+        <%= Invitation.human_attribute_name :expiration_date %>: 
+        <%= current_invitation.expiration_date ? l(current_invitation.expiration_date) : I18n.t('invitations.no_expiration_date') %>
+      </p>
+
+      <%= button_to I18n.t('invitations.cancel_button'), cancel_invitation_path(current_invitation.id),
+                    method: :patch, class: 'btn btn-danger' %>
+    <% elsif current_invitation&.processing? %>
+      <p><%= I18n.t('invitations.create.process') %></p>
+    <% else %>
+      <% if current_proposal %>
+        <div class="mb-2 text-start fst-italic">
+          "<%= current_proposal.message %>"
+        </div>
+      <% end %>
+      
+    <hr>
+      
+      <div class="mb-3">
+        <small><%= t('invitations.fill_in_details') %></small>
+      </div>
+      
+      <%= form_with(model: invitation, url: project_portfoliorrr_profile_invitations_path(project, profile.id), local: true) do |form| %>
+        <div class="mb-3">
+          <div class="row">
+            <div class="d-flex flex-column gap-3">
+              <%= form.label :expiration_days, 
+                             class: 'form-label d-none' %>
+              <%= form.number_field :expiration_days, 
+                                    class: 'form-control fs-6', 
+                                    min: 0,
+                                    placeholder: Invitation.human_attribute_name(:expiration_days) %>
+              <%= form.label :message, 
+                             class: 'form-label d-none' %>
+              <%= form.text_area :message, 
+                                 class: 'form-control',
+                                 placeholder: Invitation.human_attribute_name(:message) %>
+              <%= form.hidden_field :profile_email, 
+                                    value: profile.email %>
+              <div class="d-flex justify-content-center">
+                <% if current_proposal %>
+                  <%= form.submit t('invitations.accept_btn'), 
+                                  class: 'btn btn-primary' %>
+                <% else %>
+                  <%= form.submit t('invitations.send_invitation'), 
+                                  class: 'btn btn-primary' %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/portfoliorrr_profiles/_invitation_form.html.erb
+++ b/app/views/portfoliorrr_profiles/_invitation_form.html.erb
@@ -28,6 +28,11 @@
 <% elsif current_invitation.present? && current_invitation.processing? %>
   <p><%= I18n.t('invitations.create.process') %></p>
 <% else %>
+  <% if current_proposal %>
+    <p>Solicitação pendente</p>
+    <%= current_proposal.message %>
+  <% end %>
+
   <%= form_with(model: invitation, url: project_portfoliorrr_profile_invitations_path(project, profile.id), local: true) do |form| %>
     <div class="mb-3">
       <div class="row">
@@ -41,9 +46,13 @@
           <%= form.hidden_field :profile_email, value: profile.email %>
         </div>
         <div class="d-flex justify-content-center mb-2">
-          <%= form.submit I18n.t('invitations.send_invitation'), class: 'btn btn-primary' %>
+          <% if current_proposal %>
+            <%= form.submit 'Aceitar', class: 'btn btn-primary' %>
+          <% else %>
+            <%= form.submit I18n.t('invitations.send_invitation'), class: 'btn btn-primary' %>
+          <% end %>
         </div>
       </div>
-    </div>   
+    </div>
   <% end %>
 <% end %>

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -36,14 +36,14 @@
                   <div class="card-body">
                     <h4><%= category.name %></h4>
                     <hr>
-                    <h6><%= category.description %></h6>    
+                    <h6><%= category.description %></h6>
                   </div>
                 </div>
               </div>
             </div>
           <% end %>
         </div>
-        
+
         <div class="col-lg-4">
           <div class="card mb-4">
             <div class="card-body text-center">

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -53,9 +53,13 @@
           </div>
           <div class="card mb-4">
             <div class="card-body text-center">
-              <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation, invitation: @invitation, profile: @portfoliorrr_profile, project: @project } %>
+              <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation,
+                                                              invitation: @invitation,
+                                                              profile: @portfoliorrr_profile,
+                                                              project: @project,
+                                                              current_proposal: @current_proposal } %>
             </div>
-          </div>        
+          </div>
         </div>
       </div>
     </div>
@@ -64,4 +68,3 @@
   <h3><%= t('profile_not_available') %></h3>
   <h3><%= t('try_again_later') %></h3>
 <% end %>
-

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -51,15 +51,11 @@
               <h4 class="mb-4"><%= @portfoliorrr_profile.cover_letter %></h4>
             </div>
           </div>
-          <div class="card mb-4">
-            <div class="card-body text-center">
-              <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation,
-                                                              invitation: @invitation,
-                                                              profile: @portfoliorrr_profile,
-                                                              project: @project,
-                                                              current_proposal: @current_proposal } %>
-            </div>
-          </div>
+          <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation,
+                                                          invitation: @invitation,
+                                                          profile: @portfoliorrr_profile,
+                                                          project: @project,
+                                                          current_proposal: @current_proposal } %>
         </div>
       </div>
     </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -38,6 +38,7 @@
               <p class="card-text">
                 <%= proposal.message.truncate(@max_characters, separator: ' ') %>
               </p>
+              <%= link_to 'Visualizar', project_portfoliorrr_profile_path(@project, proposal.profile_id)%>
             </div>
             <div class="card-footer text-muted">
               <%= time_ago_in_words proposal.created_at %> <%= t(:ago) %>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -38,7 +38,9 @@
               <p class="card-text">
                 <%= proposal.message.truncate(@max_characters, separator: ' ') %>
               </p>
-              <%= link_to 'Visualizar', project_portfoliorrr_profile_path(@project, proposal.profile_id)%>
+              <%= link_to t(:view), 
+                          project_portfoliorrr_profile_path(@project, proposal.profile_id),
+                          class: 'btn btn-sm btn-outline-secondary' if proposal.pending? %>
             </div>
             <div class="card-footer text-muted">
               <%= time_ago_in_words proposal.created_at %> <%= t(:ago) %>

--- a/config/locales/models/invitations.pt-BR.yml
+++ b/config/locales/models/invitations.pt-BR.yml
@@ -40,3 +40,4 @@ pt-BR:
     empty_state: Não há convites registrados
     already_member: Este usuário já faz parte do projeto.
     no_expiration_date: Sem prazo de validade
+    fill_in_details: Preencha os dados do convite

--- a/config/locales/models/proposals.pt-BR.yml
+++ b/config/locales/models/proposals.pt-BR.yml
@@ -27,3 +27,6 @@ pt-BR:
   user_already_member_error: Usuário já faz parte deste projeto
   user_has_pending_proposals: Usuário já tem solicitação pendente para o projeto
   proposals_empty_state: Nenhuma solicitação encontrada.
+  view: Visualizar
+  new_proposal: Nova Solicitação!
+  

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -342,4 +342,62 @@ RSpec.describe Invitation, type: :model do
       expect(invitation.expiration_date).to be nil
     end
   end
+
+  describe '#accept_proposal' do
+    it 'Muda status de uma solicitação de pendente para aceita' do
+      project = create :project
+      invitation = build :invitation,
+                         project:,
+                         profile_id: 1,
+                         profile_email: 'user@email.com',
+                         status: :pending
+      proposal = create :proposal,
+                        project:,
+                        status: :pending,
+                        profile_id: 1,
+                        email: 'user@email'
+
+      invitation.accept_proposal
+
+      expect(proposal.reload.status).to eq 'accepted'
+    end
+
+    it 'Não muda status de uma solicitação de cancelada para aceita' do
+      project = create :project
+      invitation = build :invitation,
+                         project:,
+                         profile_id: 1,
+                         profile_email: 'user@email.com',
+                         status: :pending
+      proposal = create :proposal,
+                        project:,
+                        status: :cancelled,
+                        profile_id: 1,
+                        email: 'user@email.com'
+
+      invitation.accept_proposal
+
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'cancelled'
+    end
+
+    it 'Não muda status de uma solicitação recusada para aceita' do
+      project = create :project
+      invitation = build :invitation,
+                         project:,
+                         profile_id: 1,
+                         profile_email: 'user@email.com',
+                         status: :pending
+      proposal = create :proposal,
+                        project:,
+                        status: :declined,
+                        profile_id: 1,
+                        email: 'user@email.com'
+
+      invitation.accept_proposal
+
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'declined'
+    end
+  end
 end

--- a/spec/requests/proposals/user_responds_proposal_spec.rb
+++ b/spec/requests/proposals/user_responds_proposal_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe 'Usuário responde uma solicitação' do
+  context 'para um projeto do qual é lider' do
+    it 'como aceita' do
+      leader = create :user
+      project = create :project, user: leader
+      profile_id = 38
+      profile_email = 'proposal@email.com'
+      proposal = create :proposal, project:, profile_id:,
+                                   email: profile_email, status: :pending
+      params = { invitation: { profile_id:, profile_email: } }
+      json = { data: { invitation_id: 1 } }
+      fake_response = double 'faraday_response', status: 200, body: json.to_json, success?: true
+      allow(Faraday).to receive(:post).and_return fake_response
+
+      login_as leader, scope: :user
+      post(project_portfoliorrr_profile_invitations_path(project, profile_id), params:)
+
+      expect(proposal.reload.status).to eq 'accepted'
+    end
+  end
+
+  context 'para um projeto do qual é administrador' do
+    it 'sem sucesso' do
+      admin = create :user, cpf: '068.433.960-97'
+      project = create(:project)
+      project.user_roles.create({ user: admin, role: :admin })
+      profile_id = 39
+      profile_email = 'proposal@email.com'
+      proposal = create :proposal, project:, profile_id:,
+                                   email: profile_email, status: :pending
+
+      login_as admin, scope: :user
+      post project_portfoliorrr_profile_invitations_path project, profile_id
+
+      expect(response).to redirect_to root_path
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'pending'
+    end
+  end
+
+  context 'para um projeto do qual é contribuidor' do
+    it 'sem sucesso' do
+      contributor = create :user, cpf: '068.433.960-97'
+      project = create(:project)
+      project.user_roles.create!({ user: contributor, role: :contributor })
+      profile_id = 39
+      profile_email = 'proposal@email.com'
+      proposal = create :proposal, project:, profile_id:,
+                                   email: profile_email, status: :pending
+
+      login_as contributor, scope: :user
+      post project_portfoliorrr_profile_invitations_path project, profile_id
+
+      expect(response).to redirect_to root_path
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'pending'
+    end
+  end
+
+  context 'para um projeto do qual não é colaborador' do
+    it 'sem sucesso' do
+      user = create :user, cpf: '068.433.960-97'
+      project = create(:project)
+      profile_id = 39
+      profile_email = 'proposal@email.com'
+      proposal = create :proposal, project:, profile_id:,
+                                   email: profile_email, status: :pending
+
+      login_as user, scope: :user
+      post project_portfoliorrr_profile_invitations_path project, profile_id
+
+      expect(response).to redirect_to root_path
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'pending'
+    end
+  end
+
+  context 'não autenticado' do
+    it 'sem sucesso' do
+      project = create(:project)
+      profile_id = 39
+      profile_email = 'proposal@email.com'
+      proposal = create :proposal, project:, profile_id:,
+                                   email: profile_email, status: :pending
+
+      post project_portfoliorrr_profile_invitations_path project, profile_id
+
+      expect(response).to redirect_to new_user_session_path
+      expect(proposal.reload.status).not_to eq 'accepted'
+      expect(proposal.reload.status).to eq 'pending'
+    end
+  end
+end

--- a/spec/system/proposals/leader_accepts_proposal_spec.rb
+++ b/spec/system/proposals/leader_accepts_proposal_spec.rb
@@ -34,7 +34,7 @@ describe 'Líder visualiza solicitação' do
                                  profile_id: id, email: proposal_profile.email
     allow(PortfoliorrrProfile).to receive(:find).with(id).and_return(proposal_profile)
     json = { data: { invitation_id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
+    fake_response = double('faraday_response', body: json.to_json, success?: true)
     allow(Faraday).to receive(:post).and_return(fake_response)
 
     login_as leader, scope: :user
@@ -44,5 +44,8 @@ describe 'Líder visualiza solicitação' do
     expect(page).to have_current_path project_portfoliorrr_profile_path(project, id)
     expect(page).to have_content 'Convite enviado com sucesso!'
     expect(proposal.reload.status).to eq 'accepted'
+    expect(Invitation.last.project).to eq project
+    expect(Invitation.last.profile_id).to eq proposal_profile.id
+    expect(Invitation.last.status).to eq 'pending'
   end
 end

--- a/spec/system/proposals/leader_accepts_proposal_spec.rb
+++ b/spec/system/proposals/leader_accepts_proposal_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Líder aceita solicitação' do
+describe 'Líder visualiza solicitação' do
   it 'com sucesso' do
     leader = create :user
     project = create :project, user: leader
@@ -10,9 +10,6 @@ describe 'Líder aceita solicitação' do
                       message: 'Quero participar do projeto!',
                       profile_id: id, email: 'rodolfo@email.com'
     allow(PortfoliorrrProfile).to receive(:find).with(id).and_return(proposal_profile)
-    json = { data: { invitation_id: 3 } }
-    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
-    allow(Faraday).to receive(:post).and_return(fake_response)
 
     login_as leader, scope: :user
     visit project_proposals_path project
@@ -25,5 +22,27 @@ describe 'Líder aceita solicitação' do
     expect(page).to have_field 'Prazo de validade (em dias)'
     expect(page).to have_button 'Aceitar'
     expect(page).not_to have_button 'Enviar convite'
+  end
+
+  it 'e aceita' do
+    leader = create :user
+    project = create :project, user: leader
+    id = 38
+    proposal_profile = PortfoliorrrProfile.new(id:, name: 'Rodolfo', job_categories: [])
+    proposal_profile.email = 'rodolfo@email.com'
+    proposal = create :proposal, project:, status: :pending,
+                                 profile_id: id, email: proposal_profile.email
+    allow(PortfoliorrrProfile).to receive(:find).with(id).and_return(proposal_profile)
+    json = { data: { invitation_id: 3 } }
+    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
+    allow(Faraday).to receive(:post).and_return(fake_response)
+
+    login_as leader, scope: :user
+    visit project_portfoliorrr_profile_path project, id
+    click_on 'Aceitar'
+
+    expect(page).to have_current_path project_portfoliorrr_profile_path(project, id)
+    expect(page).to have_content 'Convite enviado com sucesso!'
+    expect(proposal.reload.status).to eq 'accepted'
   end
 end

--- a/spec/system/proposals/leader_accepts_proposal_spec.rb
+++ b/spec/system/proposals/leader_accepts_proposal_spec.rb
@@ -16,7 +16,7 @@ describe 'Líder visualiza solicitação' do
     click_on 'Visualizar'
 
     expect(page).to have_current_path project_portfoliorrr_profile_path(project, id)
-    expect(page).to have_content 'Solicitação pendente'
+    expect(page).to have_content 'Nova Solicitação!'
     expect(page).to have_content 'Quero participar do projeto!'
     expect(page).to have_field 'Mensagem'
     expect(page).to have_field 'Prazo de validade (em dias)'

--- a/spec/system/proposals/leader_accepts_proposal_spec.rb
+++ b/spec/system/proposals/leader_accepts_proposal_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Líder aceita solicitação' do
+  it 'com sucesso' do
+    leader = create :user
+    project = create :project, user: leader
+    id = 38
+    proposal_profile = PortfoliorrrProfile.new(id:, name: 'Rodolfo', job_categories: [])
+    create :proposal, project:, status: :pending,
+                      message: 'Quero participar do projeto!',
+                      profile_id: id, email: 'rodolfo@email.com'
+    allow(PortfoliorrrProfile).to receive(:find).with(id).and_return(proposal_profile)
+    json = { data: { invitation_id: 3 } }
+    fake_response = double('faraday_response', status: 200, body: json.to_json, success?: true)
+    allow(Faraday).to receive(:post).and_return(fake_response)
+
+    login_as leader, scope: :user
+    visit project_proposals_path project
+    click_on 'Visualizar'
+
+    expect(page).to have_current_path project_portfoliorrr_profile_path(project, id)
+    expect(page).to have_content 'Solicitação pendente'
+    expect(page).to have_content 'Quero participar do projeto!'
+    expect(page).to have_field 'Mensagem'
+    expect(page).to have_field 'Prazo de validade (em dias)'
+    expect(page).to have_button 'Aceitar'
+    expect(page).not_to have_button 'Enviar convite'
+  end
+end

--- a/spec/system/proposals/user_views_project_proposals_spec.rb
+++ b/spec/system/proposals/user_views_project_proposals_spec.rb
@@ -69,6 +69,7 @@ describe 'Usuário vê solicitações de um projeto' do
         expect(page).to have_content 'pending@email.com'
         expect(page).to have_content 'Solicitação pendente!'
         expect(page).to have_content "#{time_ago_in_words pending_proposal.created_at} atrás"
+        expect(page).to have_link 'Visualizar'
         expect(page).not_to have_content 'accepted@email.com'
         expect(page).not_to have_content 'Solicitação aceita!'
         expect(page).not_to have_content 'declined@email.com'
@@ -103,6 +104,7 @@ describe 'Usuário vê solicitações de um projeto' do
         expect(page).to have_content 'accepted@email.com'
         expect(page).to have_content 'Solicitação aceita'
         expect(page).to have_content "#{time_ago_in_words accepted_proposal.created_at} atrás"
+        expect(page).not_to have_link 'Visualizar'
         expect(page).not_to have_content 'Pendente'
         expect(page).not_to have_content 'pending@email.com'
         expect(page).not_to have_content 'Solicitação pendente'
@@ -140,6 +142,7 @@ describe 'Usuário vê solicitações de um projeto' do
         expect(page).to have_content 'declined@email.com'
         expect(page).to have_content 'Solicitação recusada'
         expect(page).to have_content "#{time_ago_in_words declined_proposal.created_at} atrás"
+        expect(page).not_to have_link 'Visualizar'
         expect(page).not_to have_content 'Aceita'
         expect(page).not_to have_content 'accepted@email.com'
         expect(page).not_to have_content 'Solicitação aceita'
@@ -177,6 +180,7 @@ describe 'Usuário vê solicitações de um projeto' do
         expect(page).to have_content 'cancelled@email.com'
         expect(page).to have_content 'Solicitação cancelada'
         expect(page).to have_content "#{time_ago_in_words cancelled_proposal.created_at} atrás"
+        expect(page).not_to have_link 'Visualizar'
         expect(page).not_to have_content 'Recusada'
         expect(page).not_to have_content 'declined@email.com'
         expect(page).not_to have_content 'Solicitação recusada'


### PR DESCRIPTION
# Objetivos alcançados

Este PR fecha a issue #77. 

Foi implementada a funcionalidade onde um líder de projeto pode aceitar a solicitação de um usuário da plataforma Portfoliorrr para participação em seu projeto. Foi adicionado um botão para visualizar detalhes de solicitações pendentes na listagem de solicitações. Este botão não aparece para solicitações que já foram aceitas, canceladas ou recusadas.

- Tela de listagem com botão de visualizar:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/681af637-7beb-467c-9fd4-53d10cdb25f4)

Ao clicar no botão de visualizar o líder é direcionado para a página de perfil do usuário que solicitou a participação no projeto. Esta página é pertencente a aplicação Cola?Bora!, sendo renderizada com dados que chegam via requisição de API. A solicitação é renderizada no mesmo card de envio de convite, mudando apenas a informação apresentada:

- Perfil com solicitação pendente:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/5f8c18ea-732b-4ee4-8547-860802304d45)

- Perfil sem solicitação pendente:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/288bcb0f-b2f0-42d5-b8ea-e76d91435168)

O card de visualização de convite e solicitação recebeu uma atualização de layout.

Quando o líder aceita a solicitação um convite é enviado para o usuário na Portfoliorrr. O líder pode preencher uma data de expiração e/ou uma mensagem.

O envio de convite já estava implementado, reutilizamos o mesmo fluxo para a confirmação de solicitação.

## Futuras implementações

No próximo PR será implementada a funcionalidade de recusar uma solicitação. Sugerimos uma futura funcionalidade de arquivar solicitações não pendentes da listagem.