### PR TITLE
Adiciona Mailer para convites de reunião

### DIFF
--- a/app/controllers/meeting_participants_controller.rb
+++ b/app/controllers/meeting_participants_controller.rb
@@ -14,6 +14,7 @@ class MeetingParticipantsController < ApplicationController
 
     if participants.all?(&:valid?)
       participants.each(&:save)
+      MeetingParticipantMailer.with(participants:).notify_meeting_participants.deliver
       redirect_to project_meeting_path(@meeting.project, @meeting), notice: t('.success')
     else
       flash.now[:alert] = t '.fail'

--- a/app/controllers/meeting_participants_controller.rb
+++ b/app/controllers/meeting_participants_controller.rb
@@ -64,6 +64,8 @@ class MeetingParticipantsController < ApplicationController
   end
 
   def send_emails(participants)
-    MeetingParticipantMailer.with(participants:).notify_meeting_participants.deliver
+    participants.each do |participant|
+      MeetingParticipantMailer.with(participant:).notify_meeting_participants.deliver
+    end
   end
 end

--- a/app/controllers/meeting_participants_controller.rb
+++ b/app/controllers/meeting_participants_controller.rb
@@ -14,7 +14,7 @@ class MeetingParticipantsController < ApplicationController
 
     if participants.all?(&:valid?)
       participants.each(&:save)
-      MeetingParticipantMailer.with(participants:).notify_meeting_participants.deliver
+      send_emails(participants)
       redirect_to project_meeting_path(@meeting.project, @meeting), notice: t('.success')
     else
       flash.now[:alert] = t '.fail'
@@ -61,5 +61,9 @@ class MeetingParticipantsController < ApplicationController
     participants_params.map do |participant|
       @meeting.meeting_participants.build(user_role_id: participant)
     end
+  end
+
+  def send_emails(participants)
+    MeetingParticipantMailer.with(participants:).notify_meeting_participants.deliver
   end
 end

--- a/app/mailers/meeting_participant_mailer.rb
+++ b/app/mailers/meeting_participant_mailer.rb
@@ -1,10 +1,10 @@
 class MeetingParticipantMailer < ApplicationMailer
   default from: 'notifications@colabora.com'
 
-  def notify_meeting_participant
-    @meeting = params[:meeting]
-    @project = @meeting.project
-    @meeting_participants = @meeting.meeting_participants
-    mail(to: @leader.email, subject: t('.subject'))
+  def notify_meeting_participants
+    @meeting_participants = params[:participants]
+    emails = @meeting_participants.map(&:email)
+
+    mail(to: emails, subject: 'Convite para Reunião')
   end
 end

--- a/app/mailers/meeting_participant_mailer.rb
+++ b/app/mailers/meeting_participant_mailer.rb
@@ -1,0 +1,10 @@
+class MeetingParticipantMailer < ApplicationMailer
+  default from: 'notifications@colabora.com'
+
+  def notify_meeting_participant
+    @meeting = params[:meeting]
+    @project = @meeting.project
+    @meeting_participants = @meeting.meeting_participants
+    mail(to: @leader.email, subject: t('.subject'))
+  end
+end

--- a/app/mailers/meeting_participant_mailer.rb
+++ b/app/mailers/meeting_participant_mailer.rb
@@ -7,6 +7,6 @@ class MeetingParticipantMailer < ApplicationMailer
     @meeting = @meeting_participants.first.meeting
     emails = @meeting_participants.map(&:email)
 
-    mail(to: emails, subject: 'Convite para Reunião')
+    mail(to: emails, subject: t('.subject'))
   end
 end

--- a/app/mailers/meeting_participant_mailer.rb
+++ b/app/mailers/meeting_participant_mailer.rb
@@ -1,8 +1,10 @@
 class MeetingParticipantMailer < ApplicationMailer
+  helper :meeting
   default from: 'notifications@colabora.com'
 
   def notify_meeting_participants
     @meeting_participants = params[:participants]
+    @meeting = @meeting_participants.first.meeting
     emails = @meeting_participants.map(&:email)
 
     mail(to: emails, subject: 'Convite para Reunião')

--- a/app/mailers/meeting_participant_mailer.rb
+++ b/app/mailers/meeting_participant_mailer.rb
@@ -3,10 +3,11 @@ class MeetingParticipantMailer < ApplicationMailer
   default from: 'notifications@colabora.com'
 
   def notify_meeting_participants
-    @meeting_participants = params[:participants]
-    @meeting = @meeting_participants.first.meeting
-    emails = @meeting_participants.map(&:email)
+    participant = params[:participant]
+    @meeting = participant.meeting
 
-    mail(to: emails, subject: t('.subject'))
+    @is_author = participant.user_role == @meeting.user_role
+
+    mail(to: participant.email, subject: t('.subject', title: @meeting.project.title))
   end
 end

--- a/app/models/meeting_participant.rb
+++ b/app/models/meeting_participant.rb
@@ -1,4 +1,6 @@
 class MeetingParticipant < ApplicationRecord
   belongs_to :meeting
   belongs_to :user_role
+  delegate :user, to: :user_role
+  delegate :email, to: :user
 end

--- a/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
+++ b/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
@@ -1,1 +1,9 @@
 <h1>Convite para Reunião</h1>
+
+<p><%= @meeting.user.full_name %> está te convidando para uma reunião:</p>
+
+<h3><%= @meeting.title %></h3>
+<p><%= Meeting.human_attribute_name :address %>: <%= link_to_address @meeting.address %></p>
+<p><%= Meeting.human_attribute_name :datetime %>: <%= @meeting.datetime.strftime("%d/%m/%Y, %H:%M") %></p>
+<p><%= Meeting.human_attribute_name :duration %>: <%= format_duration(@meeting.duration)%></p>
+<p>Para mais detalhes, clique <%= link_to 'aqui', project_meeting_url(@meeting.project, @meeting) %></p>

--- a/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
+++ b/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
@@ -1,0 +1,1 @@
+<h1>Convite para Reunião</h1>

--- a/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
+++ b/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
@@ -1,6 +1,10 @@
-<h1><%= t('.subject') %></h1>
+<h1><%= t('.subject', title: @meeting.project.title) %></h1>
 
-<p><%= @meeting.user.full_name %> <%= t('.meeting_invitation') %>:</p>
+<% if @is_author %>
+  <p><%= t('.new_meeting') %></p>
+<% else %>
+  <p><%= @meeting.user.full_name %> <%= t('.meeting_invitation') %>:</p>
+<% end %>
 
 <h3><%= @meeting.title %></h3>
 <p><%= Meeting.human_attribute_name :address %>: <%= link_to_address @meeting.address %></p>

--- a/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
+++ b/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t('.subject') %></h1>
 
-<p><%= @meeting.user.full_name %><%= t('.meeting_invitation') %>:</p>
+<p><%= @meeting.user.full_name %> <%= t('.meeting_invitation') %>:</p>
 
 <h3><%= @meeting.title %></h3>
 <p><%= Meeting.human_attribute_name :address %>: <%= link_to_address @meeting.address %></p>

--- a/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
+++ b/app/views/meeting_participant_mailer/notify_meeting_participants.html.erb
@@ -1,9 +1,9 @@
-<h1>Convite para Reunião</h1>
+<h1><%= t('.subject') %></h1>
 
-<p><%= @meeting.user.full_name %> está te convidando para uma reunião:</p>
+<p><%= @meeting.user.full_name %><%= t('.meeting_invitation') %>:</p>
 
 <h3><%= @meeting.title %></h3>
 <p><%= Meeting.human_attribute_name :address %>: <%= link_to_address @meeting.address %></p>
 <p><%= Meeting.human_attribute_name :datetime %>: <%= @meeting.datetime.strftime("%d/%m/%Y, %H:%M") %></p>
 <p><%= Meeting.human_attribute_name :duration %>: <%= format_duration(@meeting.duration)%></p>
-<p>Para mais detalhes, clique <%= link_to 'aqui', project_meeting_url(@meeting.project, @meeting) %></p>
+<p><%= t('.meeting_details')%> <%= link_to t('.here'), project_meeting_url(@meeting.project, @meeting) %></p>

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -41,7 +41,7 @@
 <div>
   <% if current_user == @meeting.user && @participants.blank? %>
     <%= link_to I18n.t('meetings.add_meeting_participants'), 
-                new_meeting_meeting_participant_path(@project, @meeting),
+                new_meeting_meeting_participant_path(@meeting),
                 class: 'btn btn-outline-primary' %>
   <% end %>
 

--- a/config/locales/mailers/meeting_participants.yml
+++ b/config/locales/mailers/meeting_participants.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  meeting_participant_mailer:
+    notify_meeting_participants:
+      subject: Convite para Reunião
+      meeting_invitation: está te convidando para uma reunião
+      here: 'aqui'
+      meeting_details: Para mais detalhes, clique

--- a/config/locales/mailers/meeting_participants.yml
+++ b/config/locales/mailers/meeting_participants.yml
@@ -1,7 +1,8 @@
 pt-BR:
   meeting_participant_mailer:
     notify_meeting_participants:
-      subject: Convite para Reunião
+      subject: Convite para Reunião - %{title}
       meeting_invitation: está te convidando para uma reunião
       here: 'aqui'
       meeting_details: Para mais detalhes, clique
+      new_meeting: 'Você tem uma nova reunião:'

--- a/spec/mailers/meeting_participant_spec.rb
+++ b/spec/mailers/meeting_participant_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe MeetingParticipantMailer, type: :mailer do
-  context '#notify_meeting_participant' do
+  include MeetingHelper
+  context '#notify_meeting_participants' do
     it 'envia email para os participantes' do
       leader = create :user, email: 'leader@email.com'
       project = create :project, user: leader
@@ -34,8 +35,11 @@ RSpec.describe MeetingParticipantMailer, type: :mailer do
       mail = MeetingParticipantMailer.with(participants: meeting.meeting_participants).notify_meeting_participants
 
       expect(mail.body).to include 'Convite para Reunião'
-      expect(mail.body).to include ''
-      expect(mail.body).to include ''
+      expect(mail.body).to include "Endereço: #{link_to_address meeting.address}"
+      expect(mail.body).to include "Data e horário: #{meeting.datetime.strftime('%d/%m/%Y, %H:%M')}"
+      expect(mail.body).to include "Duração: #{format_duration meeting.duration}"
+      expect(mail.body).to include 'Para mais detalhes, clique'
+      expect(mail.body).to include 'aqui'
     end
   end
 end

--- a/spec/mailers/meeting_participant_spec.rb
+++ b/spec/mailers/meeting_participant_spec.rb
@@ -2,15 +2,40 @@ require 'rails_helper'
 
 RSpec.describe MeetingParticipantMailer, type: :mailer do
   context '#notify_meeting_participant' do
-    it 'quando autor o adiciona a uma reunião' do
-      mail = double('mail', deliver: true)
-      mailer_double = double('MeetingPartcipantMailer', notify_meeting_participant: mail)
+    it 'envia email para os participantes' do
+      leader = create :user, email: 'leader@email.com'
+      project = create :project, user: leader
+      author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
+      author_role = create :user_role, user: author, project:, role: :admin
+      meeting = create(:meeting, project:, user_role: author_role)
+      user = create :user, cpf: '556.887.660-69', email: 'user@email.com'
+      user_role = create :user_role, user:, project:, role: :contributor
+      create(:meeting_participant, user_role: author_role, meeting:)
+      create(:meeting_participant, user_role:, meeting:)
 
-      allow(MeetingParticipantMailer).to receive(:with).and_return(mailer_double)
-      allow(mailer_double).to receive(:notify_leader_finish_task).and_return(mail)
+      mail = MeetingParticipantMailer.with(participants: meeting.meeting_participants).notify_meeting_participants
 
-      expect(mail.subject).to eq ''
-      expect(mail.to).to eq ''
+      expect(mail.subject).to eq 'Convite para Reunião'
+      expect(mail.from).to eq ['notifications@colabora.com']
+      expect(mail.to).to eq [author.email, user.email]
+    end
+
+    it 'contém detalhes da reunião' do
+      leader = create :user, email: 'leader@email.com'
+      project = create :project, user: leader
+      author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
+      author_role = create :user_role, user: author, project:, role: :admin
+      meeting = create(:meeting, project:, user_role: author_role)
+      user = create :user, cpf: '556.887.660-69', email: 'user@email.com'
+      user_role = create :user_role, user:, project:, role: :contributor
+      create(:meeting_participant, user_role: author_role, meeting:)
+      create(:meeting_participant, user_role:, meeting:)
+
+      mail = MeetingParticipantMailer.with(participants: meeting.meeting_participants).notify_meeting_participants
+
+      expect(mail.body).to include 'Convite para Reunião'
+      expect(mail.body).to include ''
+      expect(mail.body).to include ''
     end
   end
 end

--- a/spec/mailers/meeting_participant_spec.rb
+++ b/spec/mailers/meeting_participant_spec.rb
@@ -5,41 +5,63 @@ RSpec.describe MeetingParticipantMailer, type: :mailer do
   context '#notify_meeting_participants' do
     it 'envia email para os participantes' do
       leader = create :user, email: 'leader@email.com'
-      project = create :project, user: leader
+      project = create :project, user: leader, title: 'Projeto Top'
       author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
       author_role = create :user_role, user: author, project:, role: :admin
-      meeting = create(:meeting, project:, user_role: author_role)
-      user = create :user, cpf: '556.887.660-69', email: 'user@email.com'
-      user_role = create :user_role, user:, project:, role: :contributor
-      create(:meeting_participant, user_role: author_role, meeting:)
-      create(:meeting_participant, user_role:, meeting:)
+      meeting = create :meeting, project:, user_role: author_role
+      participant = create :user, cpf: '556.887.660-69', email: 'participant@email.com'
+      participant_role = create :user_role, user: participant, project:, role: :contributor
+      meeting_participant = create :meeting_participant, meeting:, user_role: participant_role
 
-      mail = MeetingParticipantMailer.with(participants: meeting.meeting_participants).notify_meeting_participants
+      mail = MeetingParticipantMailer.with(participant: meeting_participant).notify_meeting_participants
 
-      expect(mail.subject).to eq 'Convite para Reunião'
+      expect(mail.subject).to eq 'Convite para Reunião - Projeto Top'
       expect(mail.from).to eq ['notifications@colabora.com']
-      expect(mail.to).to eq [author.email, user.email]
+      expect(mail.to).to eq [participant.email]
+      expect(mail.to).not_to include leader.email
+      expect(mail.to).not_to include author.email
     end
 
-    it 'contém detalhes da reunião' do
-      leader = create :user, email: 'leader@email.com'
-      project = create :project, user: leader
-      author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
-      author_role = create :user_role, user: author, project:, role: :admin
-      meeting = create(:meeting, project:, user_role: author_role)
-      user = create :user, cpf: '556.887.660-69', email: 'user@email.com'
-      user_role = create :user_role, user:, project:, role: :contributor
-      create(:meeting_participant, user_role: author_role, meeting:)
-      create(:meeting_participant, user_role:, meeting:)
+    context 'contém detalhes da reunião' do
+      it 'quando não é o autor' do
+        leader = create :user, email: 'leader@email.com'
+        project = create :project, user: leader, title: 'Projeto Top'
+        author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
+        author_role = create :user_role, user: author, project:, role: :admin
+        meeting = create :meeting, project:, user_role: author_role
+        participant = create :user, cpf: '556.887.660-69', email: 'participant@email.com'
+        participant_role = create :user_role, user: participant, project:, role: :contributor
+        meeting_participant = create :meeting_participant, meeting:, user_role: participant_role
 
-      mail = MeetingParticipantMailer.with(participants: meeting.meeting_participants).notify_meeting_participants
+        mail = MeetingParticipantMailer.with(participant: meeting_participant).notify_meeting_participants
 
-      expect(mail.body).to include 'Convite para Reunião'
-      expect(mail.body).to include "Endereço: #{link_to_address meeting.address}"
-      expect(mail.body).to include "Data e horário: #{meeting.datetime.strftime('%d/%m/%Y, %H:%M')}"
-      expect(mail.body).to include "Duração: #{format_duration meeting.duration}"
-      expect(mail.body).to include 'Para mais detalhes, clique'
-      expect(mail.body).to include 'aqui'
+        expect(mail.body).to include 'Convite para Reunião - Projeto Top'
+        expect(mail.body).to include "#{author.full_name} está te convidando para uma reunião:"
+        expect(mail.body).to include "Endereço: #{link_to_address meeting.address}"
+        expect(mail.body).to include "Data e horário: #{meeting.datetime.strftime('%d/%m/%Y, %H:%M')}"
+        expect(mail.body).to include "Duração: #{format_duration meeting.duration}"
+        expect(mail.body).to include 'Para mais detalhes, clique'
+        expect(mail.body).to include 'aqui'
+      end
+
+      it 'quando é o autor' do
+        leader = create :user, email: 'leader@email.com'
+        project = create :project, user: leader, title: 'Projeto Top'
+        author = create :user, cpf: '412.025.650-26', email: 'author@email.com'
+        author_role = create :user_role, user: author, project:, role: :admin
+        meeting = create :meeting, project:, user_role: author_role
+        meeting_participant = create :meeting_participant, meeting:, user_role: author_role
+
+        mail = MeetingParticipantMailer.with(participant: meeting_participant).notify_meeting_participants
+
+        expect(mail.body).to include 'Convite para Reunião - Projeto Top'
+        expect(mail.body).to include 'Você tem uma nova reunião:'
+        expect(mail.body).to include "Endereço: #{link_to_address meeting.address}"
+        expect(mail.body).to include "Data e horário: #{meeting.datetime.strftime('%d/%m/%Y, %H:%M')}"
+        expect(mail.body).to include "Duração: #{format_duration meeting.duration}"
+        expect(mail.body).to include 'Para mais detalhes, clique'
+        expect(mail.body).to include 'aqui'
+      end
     end
   end
 end

--- a/spec/mailers/meeting_participant_spec.rb
+++ b/spec/mailers/meeting_participant_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe MeetingParticipantMailer, type: :mailer do
+  context '#notify_meeting_participant' do
+    it 'quando autor o adiciona a uma reunião' do
+      mail = double('mail', deliver: true)
+      mailer_double = double('MeetingPartcipantMailer', notify_meeting_participant: mail)
+
+      allow(MeetingParticipantMailer).to receive(:with).and_return(mailer_double)
+      allow(mailer_double).to receive(:notify_leader_finish_task).and_return(mail)
+
+      expect(mail.subject).to eq ''
+      expect(mail.to).to eq ''
+    end
+  end
+end

--- a/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
+++ b/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
@@ -15,10 +15,10 @@ describe 'Usuário adiciona participantes a reunião' do
     meeting = create :meeting, project:, title: 'Reunião Semanal', user_role: author_role
 
     mail = double('mail', deliver: true)
-    mailer_double = double('MeetingParticipantMailer', notify_meeting_participant: mail)
+    mailer_double = double('MeetingParticipantMailer', notify_meeting_participants: mail)
 
     allow(MeetingParticipantMailer).to receive(:with).and_return(mailer_double)
-    allow(mailer_double).to receive(:notify_meeting_participant).and_return(mail)
+    allow(mailer_double).to receive(:notify_meeting_participants).and_return(mail)
 
     login_as author
     visit project_meeting_path project, meeting
@@ -36,7 +36,7 @@ describe 'Usuário adiciona participantes a reunião' do
     expect(page).not_to have_content 'not_invited'
     expect(page).not_to have_link 'Adicionar Participantes'
     expect(page).to have_content 'Participantes adicionados com sucesso!'
-    expect(mailer_double).to have_received(:notify_meeting_participant).with(meeting.meeting_participants[0])
+    expect(mailer_double).to have_received(:notify_meeting_participants).with(meeting.meeting_participants)
   end
 
   it 'e não vê usuários que não fazem parte do projeto' do

--- a/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
+++ b/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
@@ -14,6 +14,12 @@ describe 'Usuário adiciona participantes a reunião' do
     create :user_role, project:, user: not_invited, role: :contributor
     meeting = create :meeting, project:, title: 'Reunião Semanal', user_role: author_role
 
+    mail = double('mail', deliver: true)
+    mailer_double = double('MeetingParticipantMailer', notify_meeting_participant: mail)
+
+    allow(MeetingParticipantMailer).to receive(:with).and_return(mailer_double)
+    allow(mailer_double).to receive(:notify_meeting_participant).and_return(mail)
+
     login_as author
     visit project_meeting_path project, meeting
     click_on 'Adicionar Participantes'
@@ -30,6 +36,7 @@ describe 'Usuário adiciona participantes a reunião' do
     expect(page).not_to have_content 'not_invited'
     expect(page).not_to have_link 'Adicionar Participantes'
     expect(page).to have_content 'Participantes adicionados com sucesso!'
+    expect(mailer_double).to have_received(:notify_meeting_participant).with(meeting.meeting_participants[0])
   end
 
   it 'e não vê usuários que não fazem parte do projeto' do

--- a/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
+++ b/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
@@ -36,8 +36,8 @@ describe 'Usuário adiciona participantes a reunião' do
     expect(page).not_to have_content 'not_invited'
     expect(page).not_to have_link 'Adicionar Participantes'
     expect(page).to have_content 'Participantes adicionados com sucesso!'
-    expect(mailer_double).to have_received(:notify_meeting_participants)
-    expect(mail).to have_received(:deliver)
+    expect(mailer_double).to have_received(:notify_meeting_participants).exactly(3).times
+    expect(mail).to have_received(:deliver).exactly(3).times
   end
 
   it 'e não vê usuários que não fazem parte do projeto' do

--- a/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
+++ b/spec/system/meetings/meeting_participants/user_adds_meeting_participants_spec.rb
@@ -36,7 +36,8 @@ describe 'Usuário adiciona participantes a reunião' do
     expect(page).not_to have_content 'not_invited'
     expect(page).not_to have_link 'Adicionar Participantes'
     expect(page).to have_content 'Participantes adicionados com sucesso!'
-    expect(mailer_double).to have_received(:notify_meeting_participants).with(meeting.meeting_participants)
+    expect(mailer_double).to have_received(:notify_meeting_participants)
+    expect(mail).to have_received(:deliver)
   end
 
   it 'e não vê usuários que não fazem parte do projeto' do


### PR DESCRIPTION
# Objetivos

Esse PR resolve a issue #95.

Foi implementada a funcionalidade que notifica participantes da reunião via e-mail.

![image](https://github.com/TreinaDev/td11-cola-bora/assets/92608807/50a64a1a-d366-48f8-83a8-3e573f332540)

