### PR TITLE
Corrige bug de caractere especial na busca de usuários

### DIFF
--- a/app/models/portfoliorrr_profile.rb
+++ b/app/models/portfoliorrr_profile.rb
@@ -13,7 +13,7 @@ class PortfoliorrrProfile
   end
 
   def self.search(query)
-    url = "http://localhost:4000/api/v1/profiles?search=#{query}"
+    url = "http://localhost:4000/api/v1/profiles?search=#{CGI.escape query}"
     fetch_portfoliorrr_profiles(url)
   end
 


### PR DESCRIPTION
# Objetivo alcançado

Este PR resolve a issue #116.

Incluimos o método `CGI.escape` no termo de pesquisa que é passado para a API Portfoliorrr. Antes disso, qualquer letra com acento ou caractere especial causava uma quebra.

Pesquisa por 'joão':
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/b8748323-d053-4c63-8d73-aaaeab8e2c88)

Resultado:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/aaf68166-41ae-4d67-a737-251ae707a577)

Ao adicionar `CGI.escape` no termo isso não acontece mais:

![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/cc7fa761-ad92-43e4-a353-cc09aecdc999)


## Débitos

Não conseguimos reproduzir o bug em testes. Termos de pesquisa usando caracteres especiais não quebram o teste, como destacado no print abaixo:

![Image20240214165006](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/d8b72676-a1af-48f4-9c7f-6bd386398fb1)

O termo 'mecânico' no teste passa, mas na aplicação quebra.
