### PR TITLE
Feature/lider recebe email de solicitacao

### DIFF
--- a/app/controllers/api/v1/proposals_controller.rb
+++ b/app/controllers/api/v1/proposals_controller.rb
@@ -4,12 +4,12 @@ module Api
       before_action :set_project, only: %i[create]
 
       def create
-        proposal = @project.proposals.new(proposal_params.except(:invitation_request_id))
-        proposal.portfoliorrr_proposal_id = proposal_params[:invitation_request_id]
+        @proposal = @project.proposals.new(proposal_params.except(:invitation_request_id))
+        @proposal.portfoliorrr_proposal_id = proposal_params[:invitation_request_id]
 
-        return render json: { data: { proposal_id: proposal.id } }, status: :created if proposal.save
+        return success_result if @proposal.save
 
-        render json: { errors: proposal.errors.full_messages }, status: :conflict
+        render json: { errors: @proposal.errors.full_messages }, status: :conflict
       end
 
       def update
@@ -22,6 +22,11 @@ module Api
       end
 
       private
+
+      def success_result
+        ProposalMailer.with(proposal: @proposal).notify_leader.deliver
+        render json: { data: { proposal_id: @proposal.id } }, status: :created
+      end
 
       def set_project
         @project = Project.find(proposal_params[:project_id])

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,5 +1,11 @@
 class ProposalMailer < ApplicationMailer
   default from: 'notification@colabora.com'
 
-  def notify_leader; end
+  def notify_leader
+    @proposal = params[:proposal]
+    @project = @proposal.project
+    @leader = @project.member_roles(:leader).first.user
+
+    mail to: @leader.email, subject: t('.subject')
+  end
 end

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,0 +1,5 @@
+class ProposalMailer < ApplicationMailer
+  default from: 'notification@colabora.com'
+
+  def notify_leader; end
+end

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -4,7 +4,7 @@ class ProposalMailer < ApplicationMailer
   def notify_leader
     @proposal = params[:proposal]
     @project = @proposal.project
-    @leader = @project.member_roles(:leader).first.user
+    @leader = @project.user
 
     mail to: @leader.email, subject: t('.subject')
   end

--- a/app/views/proposal_mailer/notify_leader.html.erb
+++ b/app/views/proposal_mailer/notify_leader.html.erb
@@ -1,0 +1,10 @@
+<main>
+  <h1><%= t '.project_received_a_new_proposal', project_title: @project.title %> </h1>
+  
+  <p><%= t '.proposer', email: @proposal.email %></p>
+  <p><%= t '.message', message: @proposal.message %></p>
+  
+  <%= link_to t('.view_proposal'), 
+              project_portfoliorrr_profile_url(@project, @proposal.profile_id) %>
+</main>
+

--- a/config/locales/mailers/proposal_mailer.yml
+++ b/config/locales/mailers/proposal_mailer.yml
@@ -1,0 +1,8 @@
+pt-BR:
+ proposal_mailer:
+  notify_leader:
+    subject: Nova solicitação para seu projeto!
+    project_received_a_new_proposal: Seu projeto %{project_title} recebeu uma nova solicitação!
+    proposer: "Solicitante: %{email}"
+    message: "Mensagem: %{message}"
+    view_proposal: Visualizar solicitação

--- a/spec/helpers/invitation_helper_spec.rb
+++ b/spec/helpers/invitation_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe InvitationHelper, type: :helper do
     it 'retorna tempo em dias para expiração do convite' do
       invitation = create :invitation, expiration_days: 5
 
-      expect(invitation_expiration_date(invitation)).to eq 'Expira em 4 dias'
+      expect(invitation_expiration_date(invitation)).to eq 'Expira em 5 dias'
     end
   end
 end

--- a/spec/helpers/invitation_helper_spec.rb
+++ b/spec/helpers/invitation_helper_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe InvitationHelper, type: :helper do
     end
 
     it 'retorna tempo em dias para expiração do convite' do
-      invitation = create :invitation, expiration_days: 5
+      travel_to Time.zone.now.beginning_of_day do
+        invitation = create :invitation, expiration_days: 5
 
-      expect(invitation_expiration_date(invitation)).to eq 'Expira em 5 dias'
+        expect(invitation_expiration_date(invitation)).to eq 'Expira em 5 dias'
+      end
     end
   end
 end

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProposalMailer, type: :mailer do
+  describe '#notify_leader' do
+    it 'envia email para o líder do projeto com sucesso' do
+      leader = create :user, email: 'leader@email.com'
+      project = create :project, user: leader,
+                                 title: 'Canal de Youtube'
+      proposal = create :proposal, project:,
+                                   message: 'Gostaria de participar',
+                                   email: 'proposer_portfoliorrr@email.com'
+
+      mail = ProposalMailer.with(proposal:).notify_leader
+
+      expect(mail.to).to include 'leader@email.com'
+      expect(mail.subject).to include 'Nova solicitação para seu projeto!'
+      expect(mail.body.encoded).to include 'Seu projeto Canal de Youtube recebeu uma nova solicitação!'
+      expect(mail.body.encoded).to include 'Solicitante: proposer_portfoliorrr@email.com'
+      expect(mail.body.encoded).to include 'Mensagem: Gostaria de participar'
+      link = project_portfoliorrr_profile_url project, proposal.profile_id
+      button = "<a href=\"#{link}\">Visualizar solicitação</a>"
+      expect(mail.body.encoded).to include button
+    end
+  end
+end

--- a/spec/requests/api/v1/proposals/proposal_creation_spec.rb
+++ b/spec/requests/api/v1/proposals/proposal_creation_spec.rb
@@ -11,6 +11,10 @@ describe 'Criação de requisição de participação em projeto' do
         message: 'Gostaria de participar!',
         email: 'proposer@email.com'
       } }
+      mail = double 'mail', deliver: true
+      mailer = double 'ProposalMailer'
+      allow(ProposalMailer).to receive(:with).and_return mailer
+      allow(mailer).to receive(:notify_leader).and_return mail
 
       post(api_v1_proposals_path, params:)
 
@@ -26,6 +30,7 @@ describe 'Criação de requisição de participação em projeto' do
       expect(Proposal.last.message).to eq 'Gostaria de participar!'
       expect(Proposal.last.email).to eq 'proposer@email.com'
       expect(Proposal.last.status).to eq 'pending'
+      expect(mail).to have_received :deliver
     end
 
     context 'sem sucesso' do
@@ -40,6 +45,10 @@ describe 'Criação de requisição de participação em projeto' do
           profile_id: contributor_portfoliorrr_profile_id,
           email: 'contributor@email.com'
         } }
+        mail = double 'mail', deliver: true
+        mailer = double 'ProposalMailer'
+        allow(ProposalMailer).to receive(:with).and_return mailer
+        allow(mailer).to receive(:notify_leader).and_return mail
 
         post(api_v1_proposals_path, params:)
 
@@ -47,6 +56,7 @@ describe 'Criação de requisição de participação em projeto' do
         json_response = JSON.parse(response.body)
         expect(response).to have_http_status :conflict
         expect(json_response['errors']).to eq ['Usuário já faz parte deste projeto']
+        expect(mail).not_to have_received :deliver
       end
 
       it 'se já existe uma solicitação pendente' do


### PR DESCRIPTION
# Objetivos alcançados

Este PR fecha a issue #122 

Fo criado um mailer que notifica o líder do projeto quando uma nova solicitação de participação em um de seus projetos é feito por um usuário da Portfoliorrr.

![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/d8ef99d5-1d23-442e-89a3-bd423f137350)

Quando o líder clica em 'Visualizar solicitação' ele é redirecionado para a página de perfil do solicitante dentro da plataforma do Cola?Bora!

