### PR TITLE
Redesign do layout de perfil de usuários Portfoliorrr

### DIFF
--- a/app/models/portfoliorrr_profile.rb
+++ b/app/models/portfoliorrr_profile.rb
@@ -62,8 +62,8 @@ class PortfoliorrrProfile
 
   def convert_dates(*attribute_array)
     attribute_array.flatten.each do |attribute|
-      attribute[:start_date] = Date.parse(attribute[:start_date])
-      attribute[:end_date] = Date.parse(attribute[:end_date])
+      attribute[:start_date] = Date.parse(attribute[:start_date]) if attribute[:start_date]
+      attribute[:end_date] = Date.parse(attribute[:end_date]) if attribute[:end_date]
     end
   end
 end

--- a/app/models/portfoliorrr_profile.rb
+++ b/app/models/portfoliorrr_profile.rb
@@ -1,5 +1,5 @@
 class PortfoliorrrProfile
-  attr_accessor :id, :name, :email, :job_categories, :cover_letter
+  attr_accessor :id, :name, :email, :job_categories, :cover_letter, :professional_infos, :education_infos
 
   def initialize(id:, name:, job_categories:)
     @id = id
@@ -26,6 +26,7 @@ class PortfoliorrrProfile
     profile_json = JSON.parse(response.body, symbolize_names: true)[:data]
     profile = new_profile(profile_json)
     profile.build_details(profile_json)
+    profile
   rescue Faraday::ConnectionFailed
     {}
   end
@@ -50,8 +51,19 @@ class PortfoliorrrProfile
   def build_details(profile_json)
     @email = profile_json[:email]
     @cover_letter = profile_json[:cover_letter]
-    self
+    @professional_infos = profile_json[:professional_infos]
+    @education_infos = profile_json[:education_infos]
+    convert_dates(@professional_infos, @education_infos)
   end
 
   private_class_method :fetch_portfoliorrr_profiles, :new_profile
+
+  private
+
+  def convert_dates(*attribute_array)
+    attribute_array.flatten.each do |attribute|
+      attribute[:start_date] = Date.parse(attribute[:start_date])
+      attribute[:end_date] = Date.parse(attribute[:end_date])
+    end
+  end
 end

--- a/app/views/portfoliorrr_profiles/search.html.erb
+++ b/app/views/portfoliorrr_profiles/search.html.erb
@@ -56,7 +56,5 @@
         <% end %>    
       </tbody>
     </table>
-  <% else %>
-    <%# <h3><%= t('no_users_to_display') .</h3> %>
   <% end %>
 </main>

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -4,9 +4,11 @@
   <section>
     <div class="container">
       <div class="row">
-        <h3 class="mb-3"><%= t('profile', name: @portfoliorrr_profile.name) %></h3>
+        
+        <h2 class="mb-3 display-6"><%= t('profile', name: @portfoliorrr_profile.name) %></h2>
+
         <div class="col-lg-8">
-          <div class="card mb-4">
+          <div class="card mb-4 bg-light bg-gradient shadow">
             <div class="card-body">
               <div class="row">
                 <div class="col-sm-3">
@@ -27,10 +29,20 @@
               </div>
             </div>
           </div>
-          <% @portfoliorrr_profile.job_categories.each do |category| %>
-            <div class="row">
+          
+          <div class="card mb-4 bg-light shadow">
+            <div class="card-body p-3">
+              <h5 class="my-3 text-muted"><%= t('portfoliorrr_profile.attributes.cover_letter') %></h5>
+              <p class="mb-4 fs-5">"<%= @portfoliorrr_profile.cover_letter %>"</p>
+            </div>
+          </div>
+          
+          <h3 class="mb-3"><%= t('abilities')%></h3>
+          
+          <div class="row">
+            <% @portfoliorrr_profile.job_categories.each do |category| %>
               <div class="col-md-6">
-                <div class="card mb-4 mb-md-4">
+                <div class="card mb-4 mb-md-4 bg-light shadow">
                   <div class="card-body">
                     <h4><%= category.name %></h4>
                     <hr>
@@ -38,56 +50,53 @@
                   </div>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
+          
+          <h3 class="mb-3"><%= t('portfoliorrr_profile.attributes.education_infos')%></h3>
 
-          <h2><%= t('portfoliorrr_profile.attributes.education_infos')%></h2>
-
-          <% @portfoliorrr_profile.education_infos&.each do |education| %>
-            <div class="row">
-              <div class="col-md-6">
-                <div class="card mb-4 mb-md-4">
-                  <div class="card-body">
-                    <h4><%= education[:institution] %></h4>
-                    <hr>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.institution') %>:</strong> <%= education[:institution] %></p>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.course') %>:</strong> <%= education[:course] %></p>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= l education[:start_date] %></p>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= l education[:end_date] %></p>
+          <div class="row">
+            <% @portfoliorrr_profile.education_infos&.each do |education| %>
+              <% 2.times do %>
+                <div class="col-md-6">
+                  <div class="card mb-4 mb-md-4 bg-light shadow">
+                    <div class="card-body">
+                      <h4><%= education[:institution] %></h4>
+                      <hr>
+                      <p><strong><%= t('portfoliorrr_profile.attributes.institution') %>:</strong> <%= education[:institution] %></p>
+                      <p><strong><%= t('portfoliorrr_profile.attributes.course') %>:</strong> <%= education[:course] %></p>
+                      <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= education[:start_date] ? l(education[:start_date]) : t('nil')%></p>
+                      <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= education[:end_date] ? l(education[:end_date]) : t('nil') %></p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          <% end %>
+              <% end %>
+            <% end %>
+          </div>
+          
+          <h3 class="mb-3"><%= t('portfoliorrr_profile.attributes.professional_infos') %></h3>
 
-          <h2><%= t('portfoliorrr_profile.attributes.professional_infos') %></h2>
-
-          <% @portfoliorrr_profile.professional_infos&.each do |professional| %>
-            <div class="row">
+          <div class="row">
+            <% @portfoliorrr_profile.professional_infos&.each do |professional| %>
               <div class="col-md-6">
-                <div class="card mb-4 mb-md-4">
+                <div class="card mb-4 mb-md-4 bg-light shadow">
                   <div class="card-body">
                     <h4><%= professional[:company] %></h4>
                     <hr>
                     <p><strong><%= t('portfoliorrr_profile.attributes.position') %>:</strong> <%= professional[:position] %></p>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= l professional[:start_date] %></p>
-                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= l professional[:end_date] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= professional[:start_date] ? l(professional[:start_date]) : t('nil')%></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= professional[:end_date] ? l(professional[:end_date]) : t('nil')%></p>
                     <p><strong><%= t('portfoliorrr_profile.attributes.description') %>:</strong> <%= professional[:description] %></p>
                     <p><strong><%= t('portfoliorrr_profile.attributes.current_job') %>:</strong> <%= professional[:current_job] ? t('positive') : t('negative') %></p>
                   </div>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
 
         <div class="col-lg-4">
-          <div class="card mb-4">
-            <div class="card-body text-center">
-              <h5 class="my-3"><%= t('portfoliorrr_profile.attributes.cover_letter') %></h5>
-              <h4 class="mb-4"><%= @portfoliorrr_profile.cover_letter %></h4>
-            </div>
-          </div>
+          
           <%= render partial: 'invitation_form', 
                      locals: { current_invitation: @current_invitation,
                                invitation: @invitation,

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -1,6 +1,4 @@
-<%= link_to t('back'), search_project_portfoliorrr_profiles_path(@project), class: 'btn btn-secondary' %>
-
-<h1><%= t('profile_search_title', project_title: @project.title) %></h1>
+<%= render 'shared/project_header', project: @project %>
 
 <% if @portfoliorrr_profile.present? %>
   <section>
@@ -42,6 +40,45 @@
               </div>
             </div>
           <% end %>
+
+          <h2><%= t('portfoliorrr_profile.attributes.education_infos')%></h2>
+
+          <% @portfoliorrr_profile.education_infos&.each do |education| %>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="card mb-4 mb-md-4">
+                  <div class="card-body">
+                    <h4><%= education[:institution] %></h4>
+                    <hr>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.institution') %>:</strong> <%= education[:institution] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.course') %>:</strong> <%= education[:course] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= l education[:start_date] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= l education[:end_date] %></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
+          <h2><%= t('portfoliorrr_profile.attributes.professional_infos') %></h2>
+
+          <% @portfoliorrr_profile.professional_infos&.each do |professional| %>
+            <div class="row">
+              <div class="col-md-6">
+                <div class="card mb-4 mb-md-4">
+                  <div class="card-body">
+                    <h4><%= professional[:company] %></h4>
+                    <hr>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.position') %>:</strong> <%= professional[:position] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= l professional[:start_date] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= l professional[:end_date] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.description') %>:</strong> <%= professional[:description] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.current_job') %>:</strong> <%= professional[:current_job] ? t('positive') : t('negative') %></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
         </div>
 
         <div class="col-lg-4">
@@ -51,11 +88,12 @@
               <h4 class="mb-4"><%= @portfoliorrr_profile.cover_letter %></h4>
             </div>
           </div>
-          <%= render partial: 'invitation_form', locals: { current_invitation: @current_invitation,
-                                                          invitation: @invitation,
-                                                          profile: @portfoliorrr_profile,
-                                                          project: @project,
-                                                          current_proposal: @current_proposal } %>
+          <%= render partial: 'invitation_form', 
+                     locals: { current_invitation: @current_invitation,
+                               invitation: @invitation,
+                               profile: @portfoliorrr_profile,
+                               project: @project,
+                               current_proposal: @current_proposal } %>
         </div>
       </div>
     </div>

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -108,6 +108,8 @@
     </div>
   </section>
 <% else %>
-  <h3><%= t('profile_not_available') %></h3>
-  <h3><%= t('try_again_later') %></h3>
+  <div class="text-center mt-5">
+    <p class="display-6 fs-3"><%= t('profile_not_available') %></p>
+    <p class="text-muted display-6 fs-5"><%= t('try_again_later') %></p>
+  </div>
 <% end %>

--- a/app/views/shared/_project_header.html.erb
+++ b/app/views/shared/_project_header.html.erb
@@ -32,7 +32,7 @@
       <%= link_to t(:search_users_btn),
                   search_project_portfoliorrr_profiles_path(project),
                   class: "nav-item nav-link link-body-emphasis
-                          #{'active' if current_page?(search_project_portfoliorrr_profiles_path(project))}" %>
+                          #{'active' if request.path.include?('/portfoliorrr_profiles')}" %>
       <%= link_to Invitation.model_name.human(count: 2), 
                   project_invitations_path(project),
                   class: "nav-item nav-link link-body-emphasis

--- a/config/locales/models/portfoliorrr_profile.pt-BR.yml
+++ b/config/locales/models/portfoliorrr_profile.pt-BR.yml
@@ -9,3 +9,14 @@ pt-BR:
       job_categories: Tipos de Serviços
       email: E-mail
       cover_letter: Sobre mim
+      institution: Instituição
+      course: Curso
+      start_date: Data de Início
+      end_date: Data de Término
+      description: Descrição
+      current_job: Emprego Atual
+      position: Posição
+      professional_infos: Experiência Profissional
+      education_infos: Educação
+  positive: Sim
+  negative: Não

--- a/config/locales/models/portfoliorrr_profile.pt-BR.yml
+++ b/config/locales/models/portfoliorrr_profile.pt-BR.yml
@@ -20,3 +20,5 @@ pt-BR:
       education_infos: Educação
   positive: Sim
   negative: Não
+  abilities: Habilidades
+  nil: ---

--- a/spec/helpers/invitation_helper_spec.rb
+++ b/spec/helpers/invitation_helper_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe InvitationHelper, type: :helper do
     end
 
     it 'retorna tempo em dias para expiração do convite' do
-      invitation = create :invitation, expiration_days: 5
+      travel_to Time.zone.now.beginning_of_day do
+        invitation = create :invitation, expiration_days: 5
 
-      expect(invitation_expiration_date(invitation)).to eq 'Expira em 4 dias'
+        expect(invitation_expiration_date(invitation)).to eq 'Expira em 5 dias'
+      end
     end
   end
 end

--- a/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
+++ b/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
@@ -58,13 +58,6 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
       rodolfo_profile = PortfoliorrrProfile.new id: 2, name: 'Rodolfo',
                                                 job_categories: [JobCategory.new(id: 1, name: 'Designer')]
       allow(PortfoliorrrProfile).to receive(:all).and_return([rodolfo_profile])
-      rodolfo_profile.job_categories = [
-        JobCategory.new(id: 1, name: 'Editor de Video', description: 'Canal do Youtube'),
-        JobCategory.new(id: 2, name: 'Editor de Imagem', description: 'Photoshop')
-      ]
-      rodolfo_profile.email = 'rodolfo@email.com'
-      rodolfo_profile.cover_letter = 'Sou editor de vídeos em um canal do Youtube.'
-      allow(PortfoliorrrProfile).to receive(:find).and_return(rodolfo_profile)
 
       login_as user
       visit root_path
@@ -73,16 +66,59 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
       within '#project-navbar' do
         click_on 'Procurar usuários'
       end
-      click_on 'Rodolfo'
 
-      expect(page).to have_content 'Projeto Top - Recrutamento de colaboradores'
+      expect(page).to have_link 'Rodolfo', href: project_portfoliorrr_profile_path(project, rodolfo_profile.id)
+    end
+
+    it 'com sucesso' do
+      user = create :user, cpf: '149.759.780-32'
+      project = create :project, user:, title: 'Projeto Top'
+      project.user_roles.find_by(user:).update(role: :leader)
+      rodolfo_profile = PortfoliorrrProfile.new id: 2, name: 'Rodolfo',
+                                                job_categories: [
+                                                  JobCategory.new(id: 1, name: 'Editor de Video',
+                                                                  description: 'Canal do Youtube'),
+                                                  JobCategory.new(id: 2, name: 'Editor de Imagem',
+                                                                  description: 'Photoshop')
+                                                ]
+      rodolfo_profile.email = 'rodolfo@email.com'
+      rodolfo_profile.cover_letter = 'Sou editor de vídeos em um canal do Youtube.'
+      rodolfo_profile.education_infos = [{ "institution": 'Senai',
+                                           "course": 'Web dev full stack',
+                                           "start_date": Date.parse('2022-12-12'),
+                                           "end_date": Date.parse('2023-12-12') }]
+      rodolfo_profile.professional_infos = [{ "company": 'Campus Code',
+                                              "position": 'Dev',
+                                              "start_date": Date.parse('2022-12-12'),
+                                              "end_date": Date.parse('2023-12-12'),
+                                              "description": 'Muito código',
+                                              "current_job": false }]
+      allow(PortfoliorrrProfile).to receive(:find).and_return(rodolfo_profile)
+
+      login_as user
+      visit project_portfoliorrr_profile_path project, rodolfo_profile.id
+
+      expect(page).to have_current_path project_portfoliorrr_profile_path project, rodolfo_profile.id
+      expect(page).to have_content 'Projeto: Projeto Top'
       expect(page).to have_content 'Perfil de Rodolfo'
       expect(page).to have_content "Nome\nRodolfo"
       expect(page).to have_content "E-mail\nrodolfo@email.com"
       expect(page).to have_content "Editor de Video\nCanal do Youtube"
       expect(page).to have_content "Editor de Imagem\nPhotoshop"
       expect(page).to have_content "Sobre mim\nSou editor de vídeos em um canal do Youtube."
-      expect(current_path).to eq project_portfoliorrr_profile_path project, rodolfo_profile.id
+
+      expect(page).to have_content 'Educação'
+      expect(page).to have_content 'Instituição: Senai'
+      expect(page).to have_content 'Curso: Web dev full stack'
+      expect(page).to have_content 'Data de Início: 12/12/2022'
+      expect(page).to have_content 'Data de Término: 12/12/2023'
+
+      expect(page).to have_content 'Experiência Profissional'
+      expect(page).to have_content 'Posição:'
+      expect(page).to have_content 'Data de Início: 12/12/2022'
+      expect(page).to have_content 'Data de Término: 12/12/2023'
+      expect(page).to have_content 'Descrição'
+      expect(page).to have_content 'Emprego Atual: Não'
     end
 
     it 'e também é lider de outro projeto' do
@@ -121,7 +157,7 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
 
       login_as user
       visit project_portfoliorrr_profile_path project, profile_id
-      click_on 'Voltar'
+      click_on 'Procurar usuários'
 
       expect(page).to have_current_path search_project_portfoliorrr_profiles_path project
       expect(page).to have_field 'Busca'

--- a/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
+++ b/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
@@ -86,7 +86,7 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
       rodolfo_profile.education_infos = [{ "institution": 'Senai',
                                            "course": 'Web dev full stack',
                                            "start_date": Date.parse('2022-12-12'),
-                                           "end_date": Date.parse('2023-12-12') }]
+                                           "end_date": nil }]
       rodolfo_profile.professional_infos = [{ "company": 'Campus Code',
                                               "position": 'Dev',
                                               "start_date": Date.parse('2022-12-12'),
@@ -105,13 +105,13 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
       expect(page).to have_content "E-mail\nrodolfo@email.com"
       expect(page).to have_content "Editor de Video\nCanal do Youtube"
       expect(page).to have_content "Editor de Imagem\nPhotoshop"
-      expect(page).to have_content "Sobre mim\nSou editor de vídeos em um canal do Youtube."
+      expect(page).to have_content "Sobre mim\n\"Sou editor de vídeos em um canal do Youtube.\""
 
       expect(page).to have_content 'Educação'
       expect(page).to have_content 'Instituição: Senai'
       expect(page).to have_content 'Curso: Web dev full stack'
       expect(page).to have_content 'Data de Início: 12/12/2022'
-      expect(page).to have_content 'Data de Término: 12/12/2023'
+      expect(page).to have_content 'Data de Término: ---'
 
       expect(page).to have_content 'Experiência Profissional'
       expect(page).to have_content 'Posição:'

--- a/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
+++ b/spec/system/projects/portfoliorrr_profiles/user_views_portfoliorrr_profile_details_spec.rb
@@ -52,14 +52,13 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
 
   context 'com sucesso sendo líder do projeto' do
     it 'a partir da pagina inicial' do
-      user = create :user, cpf: '149.759.780-32'
-      project = create :project, user:, title: 'Projeto Top'
-      project.user_roles.find_by(user:).update(role: :leader)
+      leader = create :user, cpf: '149.759.780-32'
+      project = create :project, user: leader, title: 'Projeto Top'
       rodolfo_profile = PortfoliorrrProfile.new id: 2, name: 'Rodolfo',
                                                 job_categories: [JobCategory.new(id: 1, name: 'Designer')]
       allow(PortfoliorrrProfile).to receive(:all).and_return([rodolfo_profile])
 
-      login_as user
+      login_as leader
       visit root_path
       click_on 'Projetos'
       click_on 'Projeto Top'
@@ -71,9 +70,8 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
     end
 
     it 'com sucesso' do
-      user = create :user, cpf: '149.759.780-32'
-      project = create :project, user:, title: 'Projeto Top'
-      project.user_roles.find_by(user:).update(role: :leader)
+      leader = create :user, cpf: '149.759.780-32'
+      project = create :project, user: leader, title: 'Projeto Top'
       rodolfo_profile = PortfoliorrrProfile.new id: 2, name: 'Rodolfo',
                                                 job_categories: [
                                                   JobCategory.new(id: 1, name: 'Editor de Video',
@@ -95,7 +93,7 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
                                               "current_job": false }]
       allow(PortfoliorrrProfile).to receive(:find).and_return(rodolfo_profile)
 
-      login_as user
+      login_as leader
       visit project_portfoliorrr_profile_path project, rodolfo_profile.id
 
       expect(page).to have_current_path project_portfoliorrr_profile_path project, rodolfo_profile.id
@@ -135,12 +133,11 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
     end
 
     it 'e não há resultado' do
-      user = create :user, cpf: '149.759.780-32'
-      project = create :project, user:, title: 'Projeto Top'
-      project.user_roles.find_by(user:).update(role: :leader)
+      leader = create :user, cpf: '149.759.780-32'
+      project = create :project, user: leader, title: 'Projeto Top'
       allow(PortfoliorrrProfile).to receive(:find).and_return({})
 
-      login_as user
+      login_as leader
       visit project_portfoliorrr_profile_path project, 999
 
       expect(page).to have_content 'Perfil não disponível'
@@ -148,14 +145,13 @@ describe 'Usuário vê detalhes de um perfil da Portfoliorrr' do
     end
 
     it 'e volta para a página de busca' do
-      user = create :user, cpf: '149.759.780-32'
-      project = create :project, user:, title: 'Projeto Top'
-      project.user_roles.find_by(user:).update(role: :leader)
+      leader = create :user, cpf: '149.759.780-32'
+      project = create :project, user: leader, title: 'Projeto Top'
       profile_id = 1
       allow(PortfoliorrrProfile).to receive(:find).and_return({})
       allow(PortfoliorrrProfile).to receive(:all).and_return([])
 
-      login_as user
+      login_as leader
       visit project_portfoliorrr_profile_path project, profile_id
       click_on 'Procurar usuários'
 


### PR DESCRIPTION
# Objetivos alcançados
Este PR fecha as issues #89 e #124 

A API de perfil da Portfoliorrr adicionou dados que ainda não eram apresentados no perfil dentro da Cola?Bora!. Estes dados, como expreiência profissional e de educação, foram adicionado na exibição. Além disso foi aplicado um leve redesign dos elementos para melhor visualização.

- Tela de perfil:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/1abcdab0-fab5-42ee-a3df-62a124a1d4b7)

Também foi modificado o design da mensagem quando um perfil não é encontrado:

![image](https://github.com/TreinaDev/td11-cola-bora/assets/93487157/633e1aa3-ed1b-4008-b8f3-7091eb5fc916)

Testes de perfil foram refatorados para que as expectativas garantam a exibição dos novos dados.
