### PR TITLE
Configurações de aplicação

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
 css: yarn watch:css
+worker: bundle exec rake solid_queue:start

--- a/app/models/job_category.rb
+++ b/app/models/job_category.rb
@@ -1,6 +1,9 @@
 class JobCategory
   attr_accessor :id, :name, :description
 
+  URL = Rails.configuration.portfoliorrr_api[:base_url] +
+        Rails.configuration.portfoliorrr_api[:job_endpoint]
+
   def initialize(id:, name:, description: nil)
     @id = id
     @name = name
@@ -8,8 +11,7 @@ class JobCategory
   end
 
   def self.all
-    url = 'http://localhost:4000/api/v1/job_categories'
-    fetch_job_categories(url)
+    fetch_job_categories(URL)
   end
 
   def self.fetch_job_categories_by_project(project_job_categories)
@@ -22,8 +24,7 @@ class JobCategory
   end
 
   def self.find(id)
-    url = "http://localhost:4000/api/v1/job_categories/#{id}"
-    response = Faraday.get(url)
+    response = Faraday.get(URL + id.to_s)
 
     return {} unless response.success?
 

--- a/app/models/portfoliorrr_profile.rb
+++ b/app/models/portfoliorrr_profile.rb
@@ -1,6 +1,11 @@
 class PortfoliorrrProfile
   attr_accessor :id, :name, :email, :job_categories, :cover_letter
 
+  URL = Rails.configuration.portfoliorrr_api[:base_url] +
+        Rails.configuration.portfoliorrr_api[:profiles_endpoint]
+  SEARCH_URL = Rails.configuration.portfoliorrr_api[:base_url] +
+               Rails.configuration.portfoliorrr_api[:profiles_search_endpoint]
+
   def initialize(id:, name:, job_categories:)
     @id = id
     @name = name
@@ -8,18 +13,15 @@ class PortfoliorrrProfile
   end
 
   def self.all
-    url = 'http://localhost:4000/api/v1/profiles'
-    fetch_portfoliorrr_profiles(url)
+    fetch_portfoliorrr_profiles(URL)
   end
 
   def self.search(query)
-    url = "http://localhost:4000/api/v1/profiles?search=#{CGI.escape query}"
-    fetch_portfoliorrr_profiles(url)
+    fetch_portfoliorrr_profiles(SEARCH_URL + CGI.escape(query))
   end
 
   def self.find(id)
-    url = "http://localhost:4000/api/v1/profiles/#{id}"
-    response = Faraday.get(url)
+    response = Faraday.get(URL + id.to_s)
 
     return {} unless response.success?
 

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -1,6 +1,7 @@
 module InvitationService
-  PORTFOLIORRR_BASE_URL = 'http://localhost:4000'.freeze
-  PORTFOLIORRR_INVITATION_URL = '/api/v1/invitations/'.freeze
+  URL = Rails.configuration.portfoliorrr_api[:base_url] +
+        Rails.configuration.portfoliorrr_api[:invitation_endpoint]
+
   class PortfoliorrrPost
     def self.send(invitation)
       @invitation = invitation
@@ -31,9 +32,8 @@ module InvitationService
 
       def post_connection
         headers = { 'Content-Type': 'application/json' }
-        url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}"
 
-        @response = Faraday.post(url, set_json.to_json, headers)
+        @response = Faraday.post(URL, set_json.to_json, headers)
       end
 
       def post_success
@@ -53,9 +53,9 @@ module InvitationService
   class PortfoliorrrPatch
     def self.send(invitation, status)
       headers = { 'Content-Type': 'application/json' }
-      url = "#{PORTFOLIORRR_BASE_URL}#{PORTFOLIORRR_INVITATION_URL}#{invitation.portfoliorrr_invitation_id}"
       json = { status: }
 
+      url = URL + invitation.id.to_s
       response = Faraday.patch(url, json.to_json, headers)
 
       return true if response.success?

--- a/app/services/proposal_service.rb
+++ b/app/services/proposal_service.rb
@@ -1,12 +1,12 @@
 module ProposalService
-  PORTFOLIORRR_BASE_URL = 'http://localhost:4000'.freeze
-  PORTFOLIORRR_PROPOSAL_URL = '/api/v1/invitation_request/'.freeze
+  URL = Rails.configuration.portfoliorrr_api[:base_url] +
+        Rails.configuration.portfoliorrr_api[:proposal_endpoint]
 
   class Decline
     def self.send(proposal)
       return unless proposal.processing?
 
-      url = PORTFOLIORRR_BASE_URL + PORTFOLIORRR_PROPOSAL_URL + proposal.portfoliorrr_proposal_id.to_s
+      url = URL + proposal.portfoliorrr_proposal_id.to_s
       header = { 'Content-Type': 'application/json' }
 
       return proposal.declined! if Faraday.patch(url, header).success?

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module ColaBora
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Configuration for the Portfolio API endpoint
+    config.portfoliorrr_api = config_for(:portfoliorrr_api)
   end
 end

--- a/config/portfoliorrr_api.yml
+++ b/config/portfoliorrr_api.yml
@@ -1,0 +1,7 @@
+shared:
+  base_url: http://localhost:4000
+  invitation_endpoint: /api/v1/invitations/
+  proposal_endpoint: /api/v1/invitation_request/
+  job_endpoint: /api/v1/job_categories/
+  profiles_endpoint: /api/v1/profiles/
+  profiles_search_endpoint: "/api/v1/profiles?search="

--- a/spec/models/job_category_spec.rb
+++ b/spec/models/job_category_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe JobCategory, type: :model do
   context '#all' do
     it 'API retorna todos os resultados' do
-      url = 'http://localhost:4000/api/v1/job_categories'
+      url = 'http://localhost:4000/api/v1/job_categories/'
       json = File.read(Rails.root.join('spec/support/json/job_categories.json'))
       fake_response = double('faraday_response', status: 200, body: json, success?: true)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
@@ -18,7 +18,7 @@ RSpec.describe JobCategory, type: :model do
     end
 
     it 'API retorna vazio' do
-      url = 'http://localhost:4000/api/v1/job_categories'
+      url = 'http://localhost:4000/api/v1/job_categories/'
       fake_response = double('faraday_response', status: 200, body: '{ "data": [] }', success?: true)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
 
@@ -29,7 +29,7 @@ RSpec.describe JobCategory, type: :model do
     end
 
     it 'API retorna erro interno' do
-      url = 'http://localhost:4000/api/v1/job_categories'
+      url = 'http://localhost:4000/api/v1/job_categories/'
       fake_response = double('faraday_response', status: 500, body: '{ "error": ["Erro interno"] }', success?: false)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
 
@@ -40,7 +40,7 @@ RSpec.describe JobCategory, type: :model do
     end
 
     it 'e não consegue se conectar na API' do
-      url = 'http://localhost:4000/api/v1/job_categories'
+      url = 'http://localhost:4000/api/v1/job_categories/'
       allow(Faraday).to receive(:get).with(url).and_raise(Faraday::ConnectionFailed)
 
       job_categories = JobCategory.all

--- a/spec/models/portfoliorrr_profile_spec.rb
+++ b/spec/models/portfoliorrr_profile_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PortfoliorrrProfile, type: :model do
   context '#all' do
     it 'API retorna todos os resultados' do
-      url = 'http://localhost:4000/api/v1/profiles'
+      url = 'http://localhost:4000/api/v1/profiles/'
       json = File.read(Rails.root.join('spec/support/json/portfoliorrr_profiles_data.json'))
       fake_response = double('faraday_response', status: 200, body: json, success?: true)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
@@ -20,7 +20,7 @@ RSpec.describe PortfoliorrrProfile, type: :model do
     end
 
     it 'API retorna vazio' do
-      url = 'http://localhost:4000/api/v1/profiles'
+      url = 'http://localhost:4000/api/v1/profiles/'
       fake_response = double('faraday_response', status: 200, body: '{ "data": [] }', success?: true)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
 
@@ -31,7 +31,7 @@ RSpec.describe PortfoliorrrProfile, type: :model do
     end
 
     it 'API retorna erro interno' do
-      url = 'http://localhost:4000/api/v1/profiles'
+      url = 'http://localhost:4000/api/v1/profiles/'
       fake_response = double('faraday_response', status: 500, body: '{ "error": ["Erro interno"] }', success?: false)
       allow(Faraday).to receive(:get).with(url).and_return(fake_response)
 
@@ -42,7 +42,7 @@ RSpec.describe PortfoliorrrProfile, type: :model do
     end
 
     it 'e não consegue se conectar na API' do
-      url = 'http://localhost:4000/api/v1/profiles'
+      url = 'http://localhost:4000/api/v1/profiles/'
       allow(Faraday).to receive(:get).with(url).and_raise(Faraday::ConnectionFailed)
 
       portfliorrr_profiles = PortfoliorrrProfile.all


### PR DESCRIPTION
# Objetivos alcançados

Este PR fecha as issues #127 e #128

Foi adicionado no Procfile o comando para rodar o executor de jobs (Solid Queue) junto com a aplicação, removendo a necessidade de dois processos separados. Além disso foi criado um arquivo YAML com as rotas da API Portfoliorrr que são usadas dentro da aplicação, centralizando em uma única localização todas as rotas, facilitando futuras mudanças.