### PR TITLE
Fix/Bug ao acessar reunião ou tarefa criada por usuário removido do p…

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,5 +1,5 @@
 class Meeting < ApplicationRecord
-  belongs_to :user_role
+  belongs_to :user_role, -> { unscope(where: :active) }, inverse_of: :meetings
   delegate :user, to: :user_role
   belongs_to :project
   has_many :meeting_participants, dependent: :destroy

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :project
-  belongs_to :user_role
+  belongs_to :user_role, -> { unscope(where: :active) }, inverse_of: :tasks
   delegate :user, to: :user_role
   belongs_to :assigned, class_name: 'User', optional: true
   after_create :expire_task

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -3,6 +3,7 @@ class UserRole < ApplicationRecord
   belongs_to :project
   has_many :meeting_participants, dependent: :destroy
   has_many :meetings, through: :meeting_participants
+  has_many :tasks, dependent: :destroy
 
   enum role: { contributor: 1, admin: 5, leader: 9 }
 

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -4,7 +4,7 @@
 
 <dl>
   <dt><%= Meeting.human_attribute_name :user_role %></dt>
-  <dd><%= @meeting.user_role.user.email %></dd>
+  <dd><%= @meeting.user_role.user.full_name %></dd>
 
   <dt><%= Meeting.human_attribute_name :duration %></dt>
   <dd><%= format_duration(@meeting.duration) %></dd>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,7 +4,7 @@
   <dt><%= Task.human_attribute_name :description %></dt>
   <dd><%= @task.description %></dd>
   <dt><%= Task.human_attribute_name :user_role %></dt>
-  <dd><%= @task.user_role.user.email %></dd>
+  <dd><%= @task.user_role.user.full_name %></dd>
   <dt><%= Task.human_attribute_name :status %></dt>
   <dd><%= I18n.t(@task.status) %></dd>
   <dt><%= Task.human_attribute_name :assigned %></dt>
@@ -22,11 +22,11 @@
 </dl>
 <br>
 <div class="d-flex mb-3">
-  <%= button_to I18n.t('tasks.start_task'), 
+  <%= button_to I18n.t('tasks.start_task'),
                 start_project_task_path(@project, @task), method: :patch,
                 class: 'btn btn-primary me-2' if @task.uninitialized? %>
-  <%= button_to I18n.t('tasks.finish_task'), 
-                finish_project_task_path(@project, @task), method: :patch, 
+  <%= button_to I18n.t('tasks.finish_task'),
+                finish_project_task_path(@project, @task), method: :patch,
                 class: 'btn btn-primary me-2' if @task.in_progress? %>
   <%= button_to I18n.t('tasks.cancel_task'),
                 cancel_project_task_path(@project, @task), method: :patch,
@@ -37,7 +37,7 @@
               class: 'btn btn-secondary' unless @task.finished? || @task.cancelled? %>
 </div>
 <div>
-  <%= link_to I18n.t('.back'), 
+  <%= link_to I18n.t('.back'),
               project_tasks_path(@task.project),
               class: 'btn btn-secondary' %>
 </div>

--- a/spec/system/meetings/user_create_meeting_spec.rb
+++ b/spec/system/meetings/user_create_meeting_spec.rb
@@ -22,7 +22,7 @@ describe 'Usuário cria reunião' do
     expect(Meeting.count).to eq 1
     expect(page).to have_content 'Reunião criada com sucesso.'
     expect(page).to have_content 'Reunião: Daily'
-    expect(page).to have_content "Autor\n#{user.email}"
+    expect(page).to have_content "Autor\n#{user.full_name}"
     expect(page).to have_content "Descrição\nSem descrição"
     expect(page).to have_content "Data e horário\n24/11/2024, 14:00"
     expect(page).to have_content "Duração\n2h"

--- a/spec/system/meetings/user_view_meeting_index_spec.rb
+++ b/spec/system/meetings/user_view_meeting_index_spec.rb
@@ -86,4 +86,22 @@ describe 'Usuário vê página de reuniões de um projeto' do
     expect(page).not_to have_content 'Adicione participantes para notificá-los'
     expect(page).not_to have_content 'Lista de Participantes'
   end
+
+  it 'e acessa uma reunião de um participante removido do projeto' do
+    leader = create :user, cpf: '850.265.590-69', email: 'participant1@email.com'
+    project = create :project, user: leader
+    author = create :user, cpf: '875.898.470-46'
+    author.profile.update first_name: 'João', last_name: 'Almeida'
+    author_role = create :user_role, project:, user: author, role: :contributor
+    meeting = create :meeting, project:, user_role: author_role, title: 'Planejamento estratégico',
+                               description: 'Vamos planejar a estratégia'
+    author_role.update active: false
+
+    login_as leader
+    visit project_meeting_path project, meeting
+
+    expect(page).to have_content 'João Almeida'
+    expect(page).to have_content 'Planejamento estratégico'
+    expect(page).to have_content 'Vamos planejar a estratégia'
+  end
 end

--- a/spec/system/tasks/user_register_task_spec.rb
+++ b/spec/system/tasks/user_register_task_spec.rb
@@ -18,7 +18,7 @@ describe 'Usuário cria tarefa' do
     click_on 'Salvar'
 
     expect(page).to have_content('Tarefa criada com sucesso')
-    expect(page).to have_content("Autor\n#{author.email}")
+    expect(page).to have_content("Autor\n#{author.full_name}")
     expect(page).to have_content('Tarefa: Bugfix do projeto')
     expect(page).to have_content("Prazo\n#{I18n.l 10.days.from_now.to_date}")
     expect(page).to have_content("Responsável\nvaleria@email.com")

--- a/spec/system/tasks/user_view_task_index_spec.rb
+++ b/spec/system/tasks/user_view_task_index_spec.rb
@@ -64,4 +64,22 @@ describe 'Usuário vê tarefas' do
     expect(page).to have_link 'Tarefa 4'
     expect(current_path).to eq project_tasks_path(project)
   end
+
+  it 'e acessa uma tarefa de um participante removido do projeto' do
+    leader = create :user, cpf: '850.265.590-69', email: 'participant1@email.com'
+    project = create :project, user: leader
+    author = create :user, cpf: '875.898.470-46'
+    author.profile.update first_name: 'João', last_name: 'Almeida'
+    author_role = create :user_role, project:, user: author, role: :contributor
+    task = create :task, project:, user_role: author_role, title: 'Planejamento estratégico',
+                         description: 'Vamos planejar a estratégia'
+    author_role.update active: false
+
+    login_as leader
+    visit project_task_path project, task
+
+    expect(page).to have_content 'João Almeida'
+    expect(page).to have_content 'Planejamento estratégico'
+    expect(page).to have_content 'Vamos planejar a estratégia'
+  end
 end


### PR DESCRIPTION

Aborda e Resolve #125 

Mudança de campo exibidido como autor da reunião/tarefa: de email para nome completo do usuário

Printas das telas:
Reunião criada por Ash:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/22228213/6a3c162d-e7ef-4eb6-999f-4e6d50dbf812)

Ash removido do projeto:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/22228213/c9fd8e8f-9cd8-439c-83e6-079d37f48be9)
![image](https://github.com/TreinaDev/td11-cola-bora/assets/22228213/037f9c48-1570-41f4-a47b-614f8c3c7c9f)

Reunião após remoção de Ash:
![image](https://github.com/TreinaDev/td11-cola-bora/assets/22228213/88b5043f-99a7-49ec-86a4-1115482cf50b)
