### PR TITLE
Remove duplicidade de perfil e ajusta mensagem de forums

### DIFF
--- a/app/views/forums/index.html.erb
+++ b/app/views/forums/index.html.erb
@@ -22,7 +22,7 @@
           </div>
         </form>
         <div v-if="filteredPosts.length === 0">
-          <h3><%= t('forums.no_posts') %></h3>
+          <%= render 'shared/empty_state', message: t('forums.no_posts') %>
         </div>
         <div class="card h-20 mb-3" v-for="item in filteredPosts" :key="item.id">
           <div class="card-header border-bottom border-3 border-success text-success bg-light bg-gradient display-6 fs-5">

--- a/app/views/portfoliorrr_profiles/show.html.erb
+++ b/app/views/portfoliorrr_profiles/show.html.erb
@@ -57,20 +57,18 @@
 
           <div class="row">
             <% @portfoliorrr_profile.education_infos&.each do |education| %>
-              <% 2.times do %>
-                <div class="col-md-6">
-                  <div class="card mb-4 mb-md-4 bg-light shadow">
-                    <div class="card-body">
-                      <h4><%= education[:institution] %></h4>
-                      <hr>
-                      <p><strong><%= t('portfoliorrr_profile.attributes.institution') %>:</strong> <%= education[:institution] %></p>
-                      <p><strong><%= t('portfoliorrr_profile.attributes.course') %>:</strong> <%= education[:course] %></p>
-                      <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= education[:start_date] ? l(education[:start_date]) : t('nil')%></p>
-                      <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= education[:end_date] ? l(education[:end_date]) : t('nil') %></p>
-                    </div>
+              <div class="col-md-6">
+                <div class="card mb-4 mb-md-4 bg-light shadow">
+                  <div class="card-body">
+                    <h4><%= education[:institution] %></h4>
+                    <hr>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.institution') %>:</strong> <%= education[:institution] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.course') %>:</strong> <%= education[:course] %></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.start_date') %>:</strong> <%= education[:start_date] ? l(education[:start_date]) : t('nil')%></p>
+                    <p><strong><%= t('portfoliorrr_profile.attributes.end_date') %>:</strong> <%= education[:end_date] ? l(education[:end_date]) : t('nil') %></p>
                   </div>
                 </div>
-              <% end %>
+              </div>
             <% end %>
           </div>
           


### PR DESCRIPTION
Resolve issue #145

Esse PR remove a duplicidade dos dados acadêmicos da página de perfil completo.

Também ajusta a mensagem de nenhuma postagem no forum para ficar no mesmo layout do restante da aplicação.

![image](https://github.com/TreinaDev/td11-cola-bora/assets/69739994/d952c184-5724-4ab5-8ccb-238d6280e2f1)
